### PR TITLE
Only show SchemaTable in the styleguide

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -10,6 +10,7 @@ module.exports = {
     (neutrino) => {
       neutrino.register('styleguide', () => ({
         webpackConfig: neutrino.config.toConfig(),
+        skipComponentsWithoutExample: true,
       }));
     },
   ]


### PR DESCRIPTION
**Closes Issue:** #8 
only show components that have a README in the styleguide and avoid rendering the others

**Applied Changes**
- added `skipComponentsWithoutExample: true` to styleguide configuration
- styleguide skips components without examples (no README files)