### PR TITLE
Fix eslint config to use React.Fragment over shorthand

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,10 +1,10 @@
-const airbnb = require('@neutrinojs/airbnb');
+const reactLint = require('@mozilla-frontend-infra/react-lint');
 const reactComponents = require('@neutrinojs/react-components');
 const jest = require('@neutrinojs/jest');
 
 module.exports = {
   use: [
-    airbnb(),
+    reactLint(),
     reactComponents(),
     jest(),
     (neutrino) => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@material-ui/core": "^4.7.1",
-    "@neutrinojs/airbnb": "9.0.0-rc.5",
+    "@mozilla-frontend-infra/react-lint": "^2.0.1",
     "@neutrinojs/jest": "9.0.0-rc.5",
     "@neutrinojs/react-components": "9.0.0-rc.5",
     "eslint": "^6.7.2",

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { shape, string } from 'prop-types';
 
 function NormalLeftRow({ schema, classes }) {
-  const name = ('name' in schema) ? `${schema.name}: ` : null;
-
-  const typeSymbol = ({
+  const name = 'name' in schema ? `${schema.name}: ` : null;
+  const typeSymbol = {
     array: '[',
     boolean: '"..."',
     integer: '"..."',
@@ -12,8 +11,7 @@ function NormalLeftRow({ schema, classes }) {
     number: '"..."',
     object: '{',
     string: '"..."',
-  }[schema.type]);
-
+  }[schema.type];
   /** Create blank line paddings only for additional keywords that
    *  will have their own lines on the according right row.
    *  This enables the left row to have matching number of lines with
@@ -21,7 +19,8 @@ function NormalLeftRow({ schema, classes }) {
    */
   const nonPaddedKeywords = ['type', 'description', 'name'];
   const blankLinePaddings = [];
-  Object.keys(schema).forEach((keyword) => {
+
+  Object.keys(schema).forEach(keyword => {
     if (!nonPaddedKeywords.includes(keyword)) {
       blankLinePaddings.push(<br key={keyword} className={classes.line} />);
     }

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -7,7 +7,7 @@ function NormalRightRow({ schema, classes }) {
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>
-        {keywords.map((keyword) => (
+        {keywords.map(keyword => (
           <p key={keyword} className={classes.line}>
             {keyword}
             {': '}
@@ -16,7 +16,7 @@ function NormalRightRow({ schema, classes }) {
         ))}
       </div>
       <div className={classes.descriptionColumn}>
-        {('description' in schema) && <p>{schema.description}</p>}
+        {'description' in schema && <p>{schema.description}</p>}
       </div>
     </div>
   );

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -25,12 +25,8 @@ const useStyles = makeStyles({
     display: 'grid',
     gridTemplateColumns: '[keyword-column] 1fr [description-column] 1fr',
   },
-  keywordColumn: {
-
-  },
-  descriptionColumn: {
-
-  },
+  keywordColumn: {},
+  descriptionColumn: {},
   line: {
     boxSizing: 'border-box',
     margin: 0,
@@ -41,7 +37,6 @@ const useStyles = makeStyles({
 
 function SchemaTable({ schema }) {
   const classes = useStyles();
-
   /**
    * Rows for the left and right column are stored separately
    * so that the left and right panels can render the rows separately.
@@ -50,25 +45,26 @@ function SchemaTable({ schema }) {
    */
   const leftRows = [];
   const rightRows = [];
-
   /**
    * TODO: define renderArray method
    *       add description comment
    */
-  const renderArray = (schemaInput) => <>{schemaInput}</>;
-
+  const renderArray = schemaInput => (
+    <React.Fragment>{schemaInput}</React.Fragment>
+  );
   /**
    * TODO: define renderCombination method
    *       add description comment
    */
-  const renderCombination = (schemaInput) => <>{schemaInput}</>;
-
+  const renderCombination = schemaInput => (
+    <React.Fragment>{schemaInput}</React.Fragment>
+  );
   /**
    * Default data type schemas (boolean, null, number, integer, string)
    * are parsed to create 'NormalLeftRow' and 'NormalRightRow' components.
-   * These will then be stored into 'leftRows' and 'rightRows' arrays respectively.
+   * These will then be stored into 'leftRows' and 'rightRows' arrays each.
    */
-  const renderDefault = (schemaInput) => {
+  const renderDefault = schemaInput => {
     const leftRow = (
       <NormalLeftRow
         key={leftRows.length + 1}
@@ -92,14 +88,16 @@ function SchemaTable({ schema }) {
    * TODO: define renderObject method
    *       add description comment
    */
-  const renderObject = (schemaInput) => <>{schemaInput}</>;
-
+  const renderObject = schemaInput => (
+    <React.Fragment>{schemaInput}</React.Fragment>
+  );
   /**
    * TODO: define renderRef method
    *       add description comment
    */
-  const renderRef = (schemaInput) => <>{schemaInput}</>;
-
+  const renderRef = schemaInput => (
+    <React.Fragment>{schemaInput}</React.Fragment>
+  );
   /**
    * Schemas are passed to different render methods according to its
    * specific type (combination, array, object, ref, and default).
@@ -109,8 +107,13 @@ function SchemaTable({ schema }) {
    * Types other than default schemas may repeatedly call this method
    * within their render method if the schema has a nested structure.
    */
-  const renderSchema = (schemaInput) => {
-    if ('allOf' in schemaInput || 'anyOf' in schemaInput || 'oneOf' in schemaInput || 'not' in schemaInput) {
+  const renderSchema = schemaInput => {
+    if (
+      'allOf' in schemaInput ||
+      'anyOf' in schemaInput ||
+      'oneOf' in schemaInput ||
+      'not' in schemaInput
+    ) {
       renderCombination(schemaInput);
     } else if ('$ref' in schemaInput) {
       renderRef(schemaInput);
@@ -125,21 +128,13 @@ function SchemaTable({ schema }) {
 
     return (
       <div className={classes.wrapper}>
-        <div className={classes.leftPanel}>
-          {leftRows}
-        </div>
-        <div className={classes.rightPanel}>
-          {rightRows}
-        </div>
+        <div className={classes.leftPanel}>{leftRows}</div>
+        <div className={classes.rightPanel}>{rightRows}</div>
       </div>
     );
   };
 
-  return (
-    <Fragment>
-      {renderSchema(schema)}
-    </Fragment>
-  );
+  return <Fragment>{renderSchema(schema)}</Fragment>;
 }
 
 SchemaTable.propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,27 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@mozilla-frontend-infra/lint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/lint/-/lint-2.0.0.tgz#081874c5e024a33e0ce0d8f91f5f54c8c4977e21"
+  integrity sha512-htjLFoY6kCN2xCQFNPkUyz9zj/MjXFCMcHpGEA6PK4uFXiNpbVQsRkLujwQQ12FNFzzbsTVl0GBgin7OOY8Ulw==
+  dependencies:
+    deepmerge "^2.2.1"
+    eslint-config-prettier "^6.4.0"
+    eslint-plugin-prettier "^3.1.1"
+    prettier "^1.18.2"
+
+"@mozilla-frontend-infra/react-lint@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/react-lint/-/react-lint-2.0.1.tgz#999eca8c28d0931f3aa3920c0ae64db35fcfd447"
+  integrity sha512-GRBFgFNU/Rp3/Pjpc7hUTP/bF1oA6MJmJyo56NUnyjYX+4ss5/lizscHNl8+IQ6iYbSmXmg5Kgxhr2x1h3Q6yg==
+  dependencies:
+    "@mozilla-frontend-infra/lint" "^2.0.0"
+    "@neutrinojs/airbnb" "9.0.0-rc.4"
+    deepmerge "^2.2.1"
+    eslint-plugin-react "^7.16.0"
+    prettier "^1.18.2"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -979,18 +1000,18 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@neutrinojs/airbnb@9.0.0-rc.5":
-  version "9.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/airbnb/-/airbnb-9.0.0-rc.5.tgz#4286445a3b1ca3d3d658c8d7fdc07ac8df7766e6"
-  integrity sha512-p3iRiy7nnnzE4WK+3vxnhBtrJccZXXvzpBvNuaCZDNXpGlMCaq99Q/MZBnEwCxMWJhxzdLIA1sOEOujHh7LO/Q==
+"@neutrinojs/airbnb@9.0.0-rc.4":
+  version "9.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/airbnb/-/airbnb-9.0.0-rc.4.tgz#f0917914a3351093d6de9878208efdcd87dde599"
+  integrity sha512-68turD/GYKP0RBluiunYjJ28ckwEP/Lpd9Dyo9xeGxQrugnDZQx2Nnb6xFKOfCKlN6nGa6rFbxu2bhKVDrhjkg==
   dependencies:
-    "@neutrinojs/eslint" "9.0.0-rc.5"
+    "@neutrinojs/eslint" "9.0.0-rc.4"
     eslint-config-airbnb "^18.0.1"
     eslint-config-airbnb-base "^14.0.0"
     eslint-plugin-import "^2.18.2"
     eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-react "^7.16.0"
-    eslint-plugin-react-hooks "^2.2.0"
+    eslint-plugin-react "^7.14.3"
+    eslint-plugin-react-hooks "^2.0.0"
 
 "@neutrinojs/banner@9.0.0-rc.5":
   version "9.0.0-rc.5"
@@ -1017,13 +1038,13 @@
   resolved "https://registry.yarnpkg.com/@neutrinojs/dev-server/-/dev-server-9.0.0-rc.5.tgz#b9e1f47baa9cfec70e5b77dd12c5642af9527ff4"
   integrity sha512-2Yd44QwRMcpSb5NGfWRl2rufcw8zGcfQIdc1w6eTpQ1CaS3ykKT6P0N/WPRwtF/HhmwHzG/be8jLMaiJ084Eyw==
 
-"@neutrinojs/eslint@9.0.0-rc.5":
-  version "9.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/eslint/-/eslint-9.0.0-rc.5.tgz#7429bb2b5bb0ca128f09465aa9bc9aba5939a616"
-  integrity sha512-88MNvoDJdybJAlrPsLSJrWpM9o5FrpJi3h/S4KWoEQA7a/t647HTc3h5jdW/yFEC1H2a5T8FEK1nD1HKUgn5jw==
+"@neutrinojs/eslint@9.0.0-rc.4":
+  version "9.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/eslint/-/eslint-9.0.0-rc.4.tgz#5d219763c08eb608c4adaf5c0d0184c8c5654f9c"
+  integrity sha512-DUaUgKYDz/0OvfYkS8BDYGxFU6/TfGv/sh+z4bLzXHkfzqrxYDa2nEU5QfMc5g/Mi44ws9nJrx+GAphiCLarug==
   dependencies:
-    babel-eslint "^10.0.3"
-    eslint-loader "^3.0.2"
+    babel-eslint "^10.0.2"
+    eslint-loader "^3.0.0"
     eslint-plugin-babel "^5.3.0"
 
 "@neutrinojs/font-loader@9.0.0-rc.5":
@@ -1858,7 +1879,7 @@ babel-core@^7.0.0-bridge.0:
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
-babel-eslint@^10.0.3:
+babel-eslint@^10.0.2:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
   integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
@@ -3456,6 +3477,13 @@ eslint-config-airbnb@^18.0.1:
     object.assign "^4.1.0"
     object.entries "^1.1.0"
 
+eslint-config-prettier@^6.4.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.7.0.tgz#9a876952e12df2b284adbd3440994bf1f39dfbb9"
+  integrity sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -3464,16 +3492,16 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-loader@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.2.tgz#5a627316a51d6f41d357b9f6f0554e91506cdd6e"
-  integrity sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==
+eslint-loader@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.3.tgz#e018e3d2722381d982b1201adb56819c73b480ca"
+  integrity sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==
   dependencies:
     fs-extra "^8.1.0"
     loader-fs-cache "^1.0.2"
     loader-utils "^1.2.3"
-    object-hash "^1.3.1"
-    schema-utils "^2.2.0"
+    object-hash "^2.0.1"
+    schema-utils "^2.6.1"
 
 eslint-module-utils@^2.4.0:
   version "2.4.1"
@@ -3534,12 +3562,19 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-react-hooks@^2.2.0:
+eslint-plugin-prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@^2.0.0, eslint-plugin-react-hooks@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
   integrity sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==
 
-eslint-plugin-react@^7.16.0:
+eslint-plugin-react@^7.14.3, eslint-plugin-react@^7.16.0:
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz#a31b3e134b76046abe3cd278e7482bd35a1d12d7"
   integrity sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==
@@ -3862,6 +3897,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.7"
@@ -4255,6 +4295,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz#6f7764f88ea11e0b514bd9bd860a132259992ca4"
   integrity sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -6744,10 +6789,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
-  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+object-hash@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.1.tgz#cef18a0c940cc60aa27965ecf49b782cbf101d96"
+  integrity sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA==
 
 object-inspect@^1.7.0:
   version "1.7.0"
@@ -7381,6 +7426,18 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.18.2:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.1.1:
   version "2.1.1"
@@ -8286,7 +8343,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.1, schema-utils@^2.2.0, schema-utils@^2.5.0, schema-utils@^2.6.0:
+schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.1.tgz#eb78f0b945c7bcfa2082b3565e8db3548011dc4f"
   integrity sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==


### PR DESCRIPTION
**Closes Issue:** #10 
set linting rule to use React.Fragment over shorthand syntax

**Applied Changes**
- override @airbnb lint config's `react/jsx-fragments` to use React.Fragment instead
- error message prints when using `<>` syntax