### PR TITLE
Add material-ui default theme

### DIFF
--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -4,22 +4,25 @@ import { makeStyles } from '@material-ui/core/styles';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   wrapper: {
     display: 'grid',
-    // TODO: change diminsions to fixed width size
     gridTemplateColumns: '[left-panel] 1fr [right-panel] 1fr',
   },
   leftPanel: {
-    // TODO: accept theme
-    backgroundColor: 'lightyellow',
+    backgroundColor: theme.palette.background.paper,
+    borderRight: `8px solid ${theme.palette.text.secondary}`,
     overflowX: 'auto',
   },
   rightPanel: {
+    backgroundColor: theme.palette.background.paper,
     overflowX: 'auto',
   },
   row: {
-    borderBottom: '1px black solid',
+    borderBottom: `1px solid ${theme.palette.text.secondary}`,
+  },
+  lastRow: {
+    borderBottom: 'none',
   },
   rightRow: {
     display: 'grid',
@@ -28,12 +31,10 @@ const useStyles = makeStyles({
   keywordColumn: {},
   descriptionColumn: {},
   line: {
-    boxSizing: 'border-box',
     margin: 0,
-    padding: 0,
     whiteSpace: 'nowrap',
   },
-});
+}));
 
 function SchemaTable({ schema }) {
   const classes = useStyles();

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   },
   leftPanel: {
     backgroundColor: theme.palette.background.paper,
-    borderRight: `8px solid ${theme.palette.text.secondary}`,
+    borderRight: `${theme.spacing(1)}px solid ${theme.palette.text.secondary}`,
     overflowX: 'auto',
   },
   rightPanel: {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,9 @@
 import React, { Fragment } from 'react';
 import { render } from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import { ThemeProvider } from '@material-ui/core/styles';
 import SchemaTable from './components/SchemaTable';
+import theme from './theme';
 
 const root = document.getElementById('root');
 
@@ -10,7 +12,9 @@ function App() {
   return (
     <Fragment>
       <CssBaseline />
-      <SchemaTable />
+      <ThemeProvider theme={theme}>
+        <SchemaTable />
+      </ThemeProvider>
     </Fragment>
   );
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,3 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+export default createMuiTheme();


### PR DESCRIPTION
**Closes Issue** #12 
configure SchemaTable component's styling based on `material-ui` default theme

**Applied Changes**
- [x] configure SchemaTable component to take a theme as input
   - [x] use default theme
   - [x] create `theme.js` file (leave blank at the moment)
- [x] polish styles for SchemaTable based on default theme