### PR TITLE
Create renderArray() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "prop-types": "^15.7.2"
   }
 }

--- a/schemas/basicDataTypes/array/additionalItems.json
+++ b/schemas/basicDataTypes/array/additionalItems.json
@@ -1,12 +1,14 @@
 {
-    "type": "array",
-    "items": [
-      {
-        "type": "number"
-      },
-      {
-        "type": "string"
-      }
-    ],
-    "additionalItems": { "type": "boolean" }
+  "type": "array",
+  "items": [
+    {
+      "type": "number"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "additionalItems": {
+    "type": "boolean"
   }
+}

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -24,7 +24,13 @@ function NormalLeftRow({ schema, classes }) {
    * This enables the left row to have matching number of lines with
    * the right row and align the lines and heights between the two rows.
    */
-  const nonPaddedKeywords = ['type', 'description', 'name', 'items'];
+  const nonPaddedKeywords = [
+    'type',
+    'description',
+    'name',
+    'items',
+    'contains',
+  ];
   const blankLinePaddings = [];
 
   Object.keys(schema).forEach(keyword => {

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -36,8 +36,12 @@ function NormalLeftRow({ schema, classes }) {
   Object.keys(schema).forEach(keyword => {
     if (!nonPaddedKeywords.includes(keyword)) {
       blankLinePaddings.push(
-        <Typography key={`${keyword} line`} className={classes.line}>
-          <br />
+        <Typography 
+          key={`${keyword} line`} 
+          component="div" 
+          variant="subtitle2" 
+          className={classes.line}>
+            <br />
         </Typography>
       );
     }
@@ -45,7 +49,7 @@ function NormalLeftRow({ schema, classes }) {
 
   return (
     <div key={schema.type} className={classes.row}>
-      <Typography component="div" className={classes.line}>
+      <Typography component="div" variant="subtitle2" className={classes.line}>
         {name && `${name}: `}
         {typeSymbol}
       </Typography>

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
 
 function NormalLeftRow({ schema, classes }) {
-  const name = 'name' in schema ? `${schema.name}: ` : null;
+  const name = 'name' in schema ? schema.name : null;
   const typeSymbol = {
     array: '[',
     boolean: '"..."',
@@ -22,16 +23,20 @@ function NormalLeftRow({ schema, classes }) {
 
   Object.keys(schema).forEach(keyword => {
     if (!nonPaddedKeywords.includes(keyword)) {
-      blankLinePaddings.push(<br key={keyword} className={classes.line} />);
+      blankLinePaddings.push(
+        <Typography key={`${keyword} line`} className={classes.line}>
+          <br />
+        </Typography>
+      );
     }
   });
 
   return (
-    <div className={classes.row}>
-      <p className={classes.line}>
-        {name}
+    <div key={schema.type} className={classes.row}>
+      <Typography component="div" className={classes.line}>
+        {name && `${name}: `}
         {typeSymbol}
-      </p>
+      </Typography>
       {blankLinePaddings}
     </div>
   );

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -3,7 +3,12 @@ import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 function NormalLeftRow({ schema, classes }) {
+  /**
+   * If schema or sub-schema has a name keyword,
+   * (ex. properties of object) store in variable to display.
+   */
   const name = 'name' in schema ? schema.name : null;
+  /** Map schema's type to a symbol for display. */
   const typeSymbol = {
     array: '[',
     boolean: '"..."',
@@ -13,10 +18,11 @@ function NormalLeftRow({ schema, classes }) {
     object: '{',
     string: '"..."',
   }[schema.type];
-  /** Create blank line paddings only for additional keywords that
-   *  will have their own lines on the according right row.
-   *  This enables the left row to have matching number of lines with
-   *  the right row and align the lines and heights between the two rows.
+  /**
+   * Create blank line paddings only for additional keywords that
+   * will have their own lines on the according right row.
+   * This enables the left row to have matching number of lines with
+   * the right row and align the lines and heights between the two rows.
    */
   const nonPaddedKeywords = ['type', 'description', 'name', 'items'];
   const blankLinePaddings = [];
@@ -43,11 +49,11 @@ function NormalLeftRow({ schema, classes }) {
 }
 
 NormalLeftRow.propTypes = {
-  /** 
+  /**
    * Schema input given to render.
    * May also be a sub-schema in case for array items,
-   * object properties or more complex schemas. 
-  */
+   * object properties or more complex schemas.
+   */
   schema: shape({
     /** Type of schema or sub-schema */
     type: string.isRequired,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -17,7 +17,7 @@ function NormalLeftRow({ schema, classes }) {
    *  This enables the left row to have matching number of lines with
    *  the right row and align the lines and heights between the two rows.
    */
-  const nonPaddedKeywords = ['type', 'description', 'name'];
+  const nonPaddedKeywords = ['type', 'description', 'name', 'items'];
   const blankLinePaddings = [];
 
   Object.keys(schema).forEach(keyword => {
@@ -39,8 +39,9 @@ function NormalLeftRow({ schema, classes }) {
 
 NormalLeftRow.propTypes = {
   schema: shape({
-    type: string.isRequired,
+    type: string,
     name: string,
+    close: string,
   }).isRequired,
   classes: shape({
     row: string.isRequired,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -36,12 +36,12 @@ function NormalLeftRow({ schema, classes }) {
   Object.keys(schema).forEach(keyword => {
     if (!nonPaddedKeywords.includes(keyword)) {
       blankLinePaddings.push(
-        <Typography 
-          key={`${keyword} line`} 
-          component="div" 
-          variant="subtitle2" 
+        <Typography
+          key={`${keyword} line`}
+          component="div"
+          variant="subtitle2"
           className={classes.line}>
-            <br />
+          <br />
         </Typography>
       );
     }

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -43,11 +43,22 @@ function NormalLeftRow({ schema, classes }) {
 }
 
 NormalLeftRow.propTypes = {
+  /** 
+   * Schema input given to render.
+   * May also be a sub-schema in case for array items,
+   * object properties or more complex schemas. 
+  */
   schema: shape({
-    type: string,
+    /** Type of schema or sub-schema */
+    type: string.isRequired,
+    /** Name of schema or sub-schema */
     name: string,
-    close: string,
   }).isRequired,
+  /**
+   * Style for rows and lines for schema viewer.
+   * Necessary to maintain consistency with right panel's
+   * rows and lines.
+   */
   classes: shape({
     row: string.isRequired,
     line: string.isRequired,

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
 
 function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema);
@@ -11,16 +12,21 @@ function NormalRightRow({ schema, classes }) {
         {keywords.map(
           keyword =>
             !nonDisplayedKeywords.includes(keyword) && (
-              <p key={keyword} className={classes.line}>
+              <Typography
+                component="div"
+                key={keyword}
+                className={classes.line}>
                 {keyword}
                 {': '}
                 {schema[keyword]}
-              </p>
+              </Typography>
             )
         )}
       </div>
       <div className={classes.descriptionColumn}>
-        {'description' in schema && <p>{schema.description}</p>}
+        {'description' in schema && (
+          <Typography component="div">{schema.description}</Typography>
+        )}
       </div>
     </div>
   );

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -3,17 +3,21 @@ import { shape, string } from 'prop-types';
 
 function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema);
+  const nonDisplayedKeywords = ['items'];
 
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>
-        {keywords.map(keyword => (
-          <p key={keyword} className={classes.line}>
-            {keyword}
-            {': '}
-            {schema[keyword]}
-          </p>
-        ))}
+        {keywords.map(
+          keyword =>
+            !nonDisplayedKeywords.includes(keyword) && (
+              <p key={keyword} className={classes.line}>
+                {keyword}
+                {': '}
+                {schema[keyword]}
+              </p>
+            )
+        )}
       </div>
       <div className={classes.descriptionColumn}>
         {'description' in schema && <p>{schema.description}</p>}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -33,11 +33,11 @@ function NormalRightRow({ schema, classes }) {
 }
 
 NormalRightRow.propTypes = {
-  /** 
+  /**
    * Schema input given to render.
    * May also be a sub-schema in case for array items,
-   * object properties or more complex schemas. 
-  */
+   * object properties or more complex schemas.
+   */
   schema: shape({
     /** Type of schema or sub-schema */
     type: string.isRequired,
@@ -50,8 +50,8 @@ NormalRightRow.propTypes = {
   classes: shape({
     row: string.isRequired,
     line: string.isRequired,
-    /** 
-     * Display the right panel in a two-column grid 
+    /**
+     * Display the right panel in a two-column grid
      * : keywordColumn, descriptionColumn
      */
     rightRow: string.isRequired,

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -19,8 +19,9 @@ function NormalRightRow({ schema, classes }) {
           keyword =>
             !nonDisplayedKeywords.includes(keyword) && (
               <Typography
-                component="div"
                 key={keyword}
+                component="div"
+                variant="subtitle2"
                 className={classes.line}>
                 {keyword}
                 {': '}
@@ -31,7 +32,7 @@ function NormalRightRow({ schema, classes }) {
       </div>
       <div className={classes.descriptionColumn}>
         {'description' in schema && (
-          <Typography component="div">{schema.description}</Typography>
+          <Typography component="div" variant="subtitle2">{schema.description}</Typography>
         )}
       </div>
     </div>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -33,15 +33,32 @@ function NormalRightRow({ schema, classes }) {
 }
 
 NormalRightRow.propTypes = {
+  /** 
+   * Schema input given to render.
+   * May also be a sub-schema in case for array items,
+   * object properties or more complex schemas. 
+  */
   schema: shape({
+    /** Type of schema or sub-schema */
     type: string.isRequired,
   }).isRequired,
+  /**
+   * Style for rows and lines for schema viewer.
+   * Necessary to maintain consistency with right panel's
+   * rows and lines.
+   */
   classes: shape({
     row: string.isRequired,
-    rightRow: string.isRequired,
-    keywordColumn: string.isRequired,
-    descriptionColumn: string.isRequired,
     line: string.isRequired,
+    /** 
+     * Display the right panel in a two-column grid 
+     * : keywordColumn, descriptionColumn
+     */
+    rightRow: string.isRequired,
+    /** Column to display keywords for the schema or sub-schema */
+    keywordColumn: string.isRequired,
+    /** Column to display description for the schema or sub-schema */
+    descriptionColumn: string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -6,6 +6,12 @@ function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema);
   const nonDisplayedKeywords = ['items'];
 
+  // TODO: specify details to see below?
+  /*
+  if (typeof schema.additionalItems === 'object') {
+  }
+  */
+
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -32,7 +32,9 @@ function NormalRightRow({ schema, classes }) {
       </div>
       <div className={classes.descriptionColumn}>
         {'description' in schema && (
-          <Typography component="div" variant="subtitle2">{schema.description}</Typography>
+          <Typography component="div" variant="subtitle2">
+            {schema.description}
+          </Typography>
         )}
       </div>
     </div>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema);
-  const nonDisplayedKeywords = ['items'];
+  const nonDisplayedKeywords = ['items', 'contains'];
 
   // TODO: specify details to see below?
   /*

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -23,3 +23,9 @@ empty array
 const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
 <SchemaTable schema={schema} />
 ```
+
+additional items (defined as schema)
+```js
+const schema = require('../../../schemas/basicDataTypes/array/additionalItems.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -18,14 +18,21 @@ const schema = require('../../../schemas/basicDataTypes/array/tupleValidation.js
 <SchemaTable schema={schema} />
 ```
 
+additional items (defined as schema)
+```js
+const schema = require('../../../schemas/basicDataTypes/array/additionalItems.json');
+<SchemaTable schema={schema} />
+```
+
+contains keyword
+```js
+const schema = require('../../../schemas/basicDataTypes/array/containsValidation.json');
+<SchemaTable schema={schema} />
+```
+
 empty array
 ```js
 const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
 <SchemaTable schema={schema} />
 ```
 
-additional items (defined as schema)
-```js
-const schema = require('../../../schemas/basicDataTypes/array/additionalItems.json');
-<SchemaTable schema={schema} />
-```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -1,6 +1,19 @@
 SchemaTable example:
 
+## Default Type Schema
 ```js
 const schema = require('../../../schemas/basicDataTypes/string/stringPattern.json');
+<SchemaTable schema={schema} />
+```
+
+## Array Type Schema
+```js
+const schema = require('../../../schemas/basicDataTypes/array/listValidation.json');
+<SchemaTable schema={schema} />
+```
+
+empty array
+```js
+const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
 <SchemaTable schema={schema} />
 ```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -1,14 +1,20 @@
-SchemaTable example:
-
-## Default Type Schema
+### Default Type Schema
 ```js
 const schema = require('../../../schemas/basicDataTypes/string/stringPattern.json');
 <SchemaTable schema={schema} />
 ```
 
-## Array Type Schema
+### Array Type Schema
+
+list validation
 ```js
 const schema = require('../../../schemas/basicDataTypes/array/listValidation.json');
+<SchemaTable schema={schema} />
+```
+
+tuple validation
+```js
+const schema = require('../../../schemas/basicDataTypes/array/tupleValidation.json');
 <SchemaTable schema={schema} />
 ```
 

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -1,10 +1,12 @@
 import React, { Fragment } from 'react';
 import { shape, string } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
 
+// TODO: add comments for styles
 const useStyles = makeStyles(theme => ({
   wrapper: {
     display: 'grid',
@@ -96,7 +98,7 @@ function SchemaTable({ schema }) {
       rightRow: (
         <div
           key={`close ${type}`}
-          className={`${classes.row} ${classes.rightRow}`}>
+          className={classNames(classes.row, classes.rightRow)}>
           <Typography component="div" className={classes.line}>
             <br />
           </Typography>
@@ -118,7 +120,7 @@ function SchemaTable({ schema }) {
   /**
    * Array type schemas start with an openArrayRow and are closed off
    * with a closeArrayRow, which both display brackets to indicate an array.
-   * Array items are parsed and rendered according to their type via 
+   * Array items are parsed and rendered according to their type via
    * calling back on the renderSchema() method. The resulting rows are
    * added sequentially in between the opening and closing rows.
    */
@@ -128,8 +130,23 @@ function SchemaTable({ schema }) {
 
     pushRow(openArrayRow);
 
+    /** Render array items only if defined */
     if ('items' in schemaInput) {
-      renderSchema(schemaInput.items);
+      /**
+       * If array is defined by tuple vaidation,
+       * render each of the item schemas individually.
+       */
+      if (Array.isArray(schemaInput.items)) {
+        schemaInput.items.forEach(item => {
+          renderSchema(item);
+        });
+      } else {
+        /**
+         * else, is defined by list vaidation,
+         * render the item schema only once.
+         */
+        renderSchema(schemaInput.items);
+      }
     }
 
     pushRow(closeArrayRow);
@@ -210,9 +227,7 @@ function SchemaTable({ schema }) {
 }
 
 SchemaTable.propTypes = {
-  /** 
-   * Schema input given to render.
-  */
+  /** Schema input given to render */
   schema: shape({
     /** Type of schema */
     type: string,
@@ -220,9 +235,7 @@ SchemaTable.propTypes = {
 };
 
 SchemaTable.defaultProps = {
-  /** 
-   * Null type schema is set as default prop.
-  */
+  /** Null type schema is set as default prop */
   schema: {
     type: 'null',
   },

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -154,17 +154,16 @@ function SchemaTable({ schema }) {
       }
     }
 
-    /*
+    /** Render contains keyword if defined */
     if ('contains' in schemaInput) {
+      renderSchema(schemaInput.contains);
     }
-    */
 
     /**
      * Add a extra row for additionalItems defined as schema.
      * (If additionalItems is defined simply as a boolean value,
      *  will be handled in openArrayRow's NormalRightRow instead)
      */
-
     if (typeof schemaInput.additionalItems === 'object') {
       // TODO: alter the sub-schema to include extra description?
       renderSchema(schemaInput.additionalItems);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { shape, string } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
 
@@ -68,26 +69,37 @@ function SchemaTable({ schema }) {
       />
     ),
   });
+  // TODO: refactor closeRow into separate component
   /**
    * Create a row to close off an array or object type schema.
    * The left row displays a closing bracket of the type while
    * the right row only consists of blank line padding.
    */
   const createClosingRow = type => {
-    const typeSymbol = {
+    const clostTypeSymbol = {
       array: ']',
       object: '}',
     }[type];
 
     return {
       leftRow: (
-        <div className={classes.row}>
-          <p className={classes.line}>{typeSymbol}</p>
+        <div key={`close ${type}`} className={classes.row}>
+          <Typography component="div" className={classes.line}>
+            {clostTypeSymbol}
+          </Typography>
         </div>
       ),
+      /** TODO: may have to restrucutre closeRightRow to include
+       *        keywordColumn, descriptionColumn for overall consistency
+       *        with <NormalRightRow />
+       */
       rightRow: (
-        <div className={`${classes.row} ${classes.rightRow}`}>
-          <br key={`close ${type}`} className={classes.line} />
+        <div
+          key={`close ${type}`}
+          className={`${classes.row} ${classes.rightRow}`}>
+          <Typography component="div" className={classes.line}>
+            <br />
+          </Typography>
         </div>
       ),
     };
@@ -104,11 +116,11 @@ function SchemaTable({ schema }) {
   };
 
   /**
-   * Array data type schemas start with an openArrayRow, which displays
-   * an open bracket symbol along with keywords describing the array schema.
-   * Then, array items are parsed to create
-   *
-   * Finally,
+   * Array type schemas start with an openArrayRow and are closed off
+   * with a closeArrayRow, which both display brackets to indicate an array.
+   * In between those two rows, array items are parsed and rendered 
+   * according to their type via calling back on the renderSchema() method. 
+   * The rows created are added sequentially below the openArrayRow.
    */
   function renderArray(schemaInput) {
     const openArrayRow = createNormalRow(schemaInput);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -125,7 +125,11 @@ function SchemaTable({ schema }) {
    * added sequentially in between the opening and closing rows.
    */
   function renderArray(schemaInput) {
-    const openArrayRow = createNormalRow(schemaInput);
+    const { additionalItems, ...addItemsKeyExcluded } = schemaInput;
+    const openArrayRow =
+      typeof schemaInput.additionalItems === 'object'
+        ? createNormalRow(addItemsKeyExcluded)
+        : createNormalRow(schemaInput);
     const closeArrayRow = createClosingRow(schemaInput.type);
 
     pushRow(openArrayRow);
@@ -133,8 +137,9 @@ function SchemaTable({ schema }) {
     /** Render array items only if defined */
     if ('items' in schemaInput) {
       /**
-       * If array is defined by tuple vaidation,
-       * render each of the item schemas individually.
+       * If array items are defined by tuple vaidation (each item may
+       * have a different schema and the order of items is important),
+       * render each of the item schemas sequentially.
        */
       if (Array.isArray(schemaInput.items)) {
         schemaInput.items.forEach(item => {
@@ -142,11 +147,27 @@ function SchemaTable({ schema }) {
         });
       } else {
         /**
-         * else, is defined by list vaidation,
-         * render the item schema only once.
+         * else, items are defined by list vaidation (each item matches
+         *  the same schema), render the item schema only once.
          */
         renderSchema(schemaInput.items);
       }
+    }
+
+    /*
+    if ('contains' in schemaInput) {
+    }
+    */
+
+    /**
+     * Add a extra row for additionalItems defined as schema.
+     * (If additionalItems is defined simply as a boolean value,
+     *  will be handled in openArrayRow's NormalRightRow instead)
+     */
+
+    if (typeof schemaInput.additionalItems === 'object') {
+      // TODO: alter the sub-schema to include extra description?
+      renderSchema(schemaInput.additionalItems);
     }
 
     pushRow(closeArrayRow);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -118,9 +118,9 @@ function SchemaTable({ schema }) {
   /**
    * Array type schemas start with an openArrayRow and are closed off
    * with a closeArrayRow, which both display brackets to indicate an array.
-   * In between those two rows, array items are parsed and rendered 
-   * according to their type via calling back on the renderSchema() method. 
-   * The rows created are added sequentially below the openArrayRow.
+   * Array items are parsed and rendered according to their type via 
+   * calling back on the renderSchema() method. The resulting rows are
+   * added sequentially in between the opening and closing rows.
    */
   function renderArray(schemaInput) {
     const openArrayRow = createNormalRow(schemaInput);
@@ -210,12 +210,19 @@ function SchemaTable({ schema }) {
 }
 
 SchemaTable.propTypes = {
+  /** 
+   * Schema input given to render.
+  */
   schema: shape({
+    /** Type of schema */
     type: string,
   }),
 };
 
 SchemaTable.defaultProps = {
+  /** 
+   * Null type schema is set as default prop.
+  */
   schema: {
     type: 'null',
   },

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -69,6 +69,31 @@ function SchemaTable({ schema }) {
     ),
   });
   /**
+   * Create a row to close off an array or object type schema.
+   * The left row displays a closing bracket of the type while
+   * the right row only consists of blank line padding.
+   */
+  const createClosingRow = type => {
+    const typeSymbol = {
+      array: ']',
+      object: '}',
+    }[type];
+
+    return {
+      leftRow: (
+        <div className={classes.row}>
+          <p className={classes.line}>{typeSymbol}</p>
+        </div>
+      ),
+      rightRow: (
+        <div className={`${classes.row} ${classes.rightRow}`}>
+          <br key={`close ${type}`} className={classes.line} />
+        </div>
+      ),
+    };
+  };
+
+  /**
    * Takes a single row as input, created from createNormalRow()
    * method, and pushes the left column and right column of the
    * row into the leftRows and rightRows respectively.
@@ -79,11 +104,23 @@ function SchemaTable({ schema }) {
   };
 
   /**
-   * TODO: define renderArray method
-   *       add description comment
+   * Array data type schemas start with an openArrayRow, which displays
+   * an open bracket symbol along with keywords describing the array schema.
+   * Then, array items are parsed to create
+   *
+   * Finally,
    */
   function renderArray(schemaInput) {
-    return <React.Fragment>{schemaInput}</React.Fragment>;
+    const openArrayRow = createNormalRow(schemaInput);
+    const closeArrayRow = createClosingRow(schemaInput.type);
+
+    pushRow(openArrayRow);
+
+    if ('items' in schemaInput) {
+      renderSchema(schemaInput.items);
+    }
+
+    pushRow(closeArrayRow);
   }
 
   /**

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -89,7 +89,10 @@ function SchemaTable({ schema }) {
     return {
       leftRow: (
         <div key={`close ${type}`} className={classes.row}>
-          <Typography component="div" variant="subtitle2" className={classes.line}>
+          <Typography
+            component="div"
+            variant="subtitle2"
+            className={classes.line}>
             {clostTypeSymbol}
           </Typography>
         </div>
@@ -102,9 +105,17 @@ function SchemaTable({ schema }) {
         <div
           key={`close ${type}`}
           className={classNames(classes.row, classes.rightRow)}>
-          <Typography component="div" variant="subtitle2" className={classes.line}>
-            <br />
-          </Typography>
+          <div className={classes.keywordColumn}>
+            <Typography
+              component="div"
+              variant="subtitle2"
+              className={classes.line}>
+              <br />
+            </Typography>
+          </div>
+          <div className={classes.descriptionColumn}>
+            <Typography component="div" variant="subtitle2" />
+          </div>
         </div>
       ),
     };

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -46,6 +46,37 @@ function SchemaTable({ schema }) {
    */
   const leftRows = [];
   const rightRows = [];
+  /**
+   * Create a single normal row (left and right column each).
+   * The result is stored in an object format in order for the
+   * pushRow() method to easily access each left and right column
+   * of the single row and push them to leftRows and rightRows respectively.
+   */
+  const createNormalRow = schemaInput => ({
+    leftRow: (
+      <NormalLeftRow
+        key={leftRows.length + 1}
+        schema={schemaInput}
+        classes={classes}
+      />
+    ),
+    rightRow: (
+      <NormalRightRow
+        key={rightRows.length + 1}
+        schema={schemaInput}
+        classes={classes}
+      />
+    ),
+  });
+  /**
+   * Takes a single row as input, created from createNormalRow()
+   * method, and pushes the left column and right column of the
+   * row into the leftRows and rightRows respectively.
+   */
+  const pushRow = row => {
+    leftRows.push(row.leftRow);
+    rightRows.push(row.rightRow);
+  };
 
   /**
    * TODO: define renderArray method
@@ -69,23 +100,9 @@ function SchemaTable({ schema }) {
    * These will then be stored into 'leftRows' and 'rightRows' arrays each.
    */
   function renderDefault(schemaInput) {
-    const leftRow = (
-      <NormalLeftRow
-        key={leftRows.length + 1}
-        schema={schemaInput}
-        classes={classes}
-      />
-    );
-    const rightRow = (
-      <NormalRightRow
-        key={rightRows.length + 1}
-        schema={schemaInput}
-        classes={classes}
-      />
-    );
+    const normalRow = createNormalRow(schemaInput);
 
-    leftRows.push(leftRow);
-    rightRows.push(rightRow);
+    pushRow(normalRow);
   }
 
   /**

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -86,7 +86,7 @@ function SchemaTable({ schema }) {
     return {
       leftRow: (
         <div key={`close ${type}`} className={classes.row}>
-          <Typography component="div" className={classes.line}>
+          <Typography component="div" variant="subtitle2" className={classes.line}>
             {clostTypeSymbol}
           </Typography>
         </div>
@@ -99,7 +99,7 @@ function SchemaTable({ schema }) {
         <div
           key={`close ${type}`}
           className={classNames(classes.row, classes.rightRow)}>
-          <Typography component="div" className={classes.line}>
+          <Typography component="div" variant="subtitle2" className={classes.line}>
             <br />
           </Typography>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@4.2.x, clean-css@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"


### PR DESCRIPTION
**Closes Issue** #13 
create a method to render array type schemas

**Applied Changes**
- [x] create array format in `SchemaTable`

   - encapsulated between `[` and `]`

   - each of the array items should call on renderSchema
- [x] render `list validation` type schema
- [x] render exception cases: empty array schema
- [x] render `tuple validation` type schema
- [x] render `contains` validation type schema
- [x] render `additionalItems`