### PR TITLE
Find more consistent way to display types

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -3,15 +3,15 @@ import { shape, string } from 'prop-types';
 
 function NormalLeftRow({ schema, classes }) {
   const name = 'name' in schema ? `${schema.name}: ` : null;
-  const typeSymbol = {
-    array: '[',
-    boolean: '"..."',
-    integer: '"..."',
-    null: '"..."',
-    number: '"..."',
-    object: '{',
-    string: '"..."',
-  }[schema.type];
+  const typeSymbol =
+    schema.type === 'array' || schema.type === 'object' ? (
+      {
+        array: '[',
+        object: '{',
+      }[schema.type]
+    ) : (
+      <code className={classes.code}>{schema.type}</code>
+    );
   /** Create blank line paddings only for additional keywords that
    *  will have their own lines on the according right row.
    *  This enables the left row to have matching number of lines with
@@ -45,6 +45,7 @@ NormalLeftRow.propTypes = {
   classes: shape({
     row: string.isRequired,
     line: string.isRequired,
+    code: string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   },
   leftPanel: {
     backgroundColor: theme.palette.background.paper,
-    borderRight: `${theme.spacing(1)}px solid ${theme.palette.text.secondary}`,
+    borderRight: `${theme.spacing(1)}px solid ${theme.palette.grey[300]}`,
     overflowX: 'auto',
   },
   rightPanel: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
     overflowX: 'auto',
   },
   row: {
-    borderBottom: `1px solid ${theme.palette.text.secondary}`,
+    borderBottom: `2px solid ${theme.palette.grey[300]}`,
   },
   lastRow: {
     borderBottom: 'none',
@@ -33,6 +33,9 @@ const useStyles = makeStyles(theme => ({
   line: {
     margin: 0,
     whiteSpace: 'nowrap',
+  },
+  code: {
+    backgroundColor: theme.palette.grey[300],
   },
 }));
 


### PR DESCRIPTION
**Closes Issue** #20 
find a more consistent way of conveying types between default types and array, object types while also replacing the use of `"..."`

**Applied Changes**
- types are now explicitly declared in the left panel

- `"..."` usage is replaced by a highlighted text
   - ex. `string` 