### PR TITLE
Fix keywords formats in NormalRightRow

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -26,9 +26,13 @@ function NormalLeftRow({ schema, classes }) {
     'contains',
   ];
   const blankLinePaddings = [];
+  const skipKeywords = ['type', 'description', 'name'];
+  const keywords = Object.keys(schema).filter(
+    key => !skipKeywords.includes(key)
+  );
 
-  Object.keys(schema).forEach(keyword => {
-    if (!nonPaddedKeywords.includes(keyword)) {
+  keywords.forEach((keyword, i) => {
+    if (i > 0) {
       blankLinePaddings.push(
         <Typography
           key={`${keyword} line`}

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -13,20 +13,15 @@ function NormalLeftRow({ schema, classes }) {
     ) : (
       <code className={classes.code}>{schema.type}</code>
     );
-  /** Create blank line paddings only for additional keywords that
-   *  will have their own lines on the according right row.
-   *  This enables the left row to have matching number of lines with
-   *  the right row and align the lines and heights between the two rows.
+  /**
+   * Create blank line paddings only for additional keywords
+   * (skip keywords which are not displayed in NormalRightRow)
+   * that will have their own lines on the according right row.
+   * This enables the left row to have matching number of lines with
+   * the right row and align the lines and heights between the two rows.
    */
-  const nonPaddedKeywords = [
-    'type',
-    'description',
-    'name',
-    'items',
-    'contains',
-  ];
   const blankLinePaddings = [];
-  const skipKeywords = ['type', 'description', 'name'];
+  const skipKeywords = ['type', 'description', 'name', 'items', 'contains'];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,8 +1,13 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 function NormalRightRow({ schema, classes }) {
+  /**
+   * Skip keywords illustrated in other parts of the SchemaTable
+   * : either in symbols in the left panel or in the description column.
+   *   (ex. 'type' is displayed in highlighted form in left panel)
+   */
   const skipKeywords = ['type', 'name', 'description', 'items', 'contains'];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
@@ -19,19 +24,17 @@ function NormalRightRow({ schema, classes }) {
             <br />
           </Typography>
         ) : (
-          <Fragment>
-            {keywords.map(keyword => (
-              <Typography
-                key={keyword}
-                component="div"
-                variant="subtitle2"
-                className={classes.line}>
-                {keyword}
-                {': '}
-                {`${schema[keyword]}`}
-              </Typography>
-            ))}
-          </Fragment>
+          keywords.map(keyword => (
+            <Typography
+              key={keyword}
+              component="div"
+              variant="subtitle2"
+              className={classes.line}>
+              {keyword}
+              {': '}
+              {`${schema[keyword]}`}
+            </Typography>
+          ))
         )}
       </div>
       <div className={classes.descriptionColumn}>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -24,7 +24,7 @@ function NormalRightRow({ schema, classes }) {
               <p key={keyword} className={classes.line}>
                 {keyword}
                 {': '}
-                {schema[keyword]}
+                {`${schema[keyword]}`}
               </p>
             ))}
           </Fragment>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,33 +1,33 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 function NormalRightRow({ schema, classes }) {
-  const keywords = Object.keys(schema);
-  const nonDisplayedKeywords = ['items', 'contains'];
-
-  // TODO: specify details to see below?
-  /*
-  if (typeof schema.additionalItems === 'object') {
-  }
-  */
+  const skipKeywords = ['type', 'name', 'description', 'items', 'contains'];
+  const keywords = Object.keys(schema).filter(
+    key => !skipKeywords.includes(key)
+  );
 
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>
-        {keywords.map(
-          keyword =>
-            !nonDisplayedKeywords.includes(keyword) && (
-              <Typography
-                key={keyword}
-                component="div"
-                variant="subtitle2"
-                className={classes.line}>
+        {keywords.length === 0 ? (
+          <Typography
+            component="div"
+            variant="subtitle2"
+            className={classes.line}>
+            <br />
+          </Typography>
+        ) : (
+          <Fragment>
+            {keywords.map(keyword => (
+              <p key={keyword} className={classes.line}>
                 {keyword}
                 {': '}
                 {schema[keyword]}
-              </Typography>
-            )
+              </p>
+            ))}
+          </Fragment>
         )}
       </div>
       <div className={classes.descriptionColumn}>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -21,11 +21,15 @@ function NormalRightRow({ schema, classes }) {
         ) : (
           <Fragment>
             {keywords.map(keyword => (
-              <p key={keyword} className={classes.line}>
+              <Typography
+                key={keyword}
+                component="div"
+                variant="subtitle2"
+                className={classes.line}>
                 {keyword}
                 {': '}
                 {`${schema[keyword]}`}
-              </p>
+              </Typography>
             ))}
           </Fragment>
         )}

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -139,6 +139,10 @@ function SchemaTable({ schema }) {
    * added sequentially in between the opening and closing rows.
    */
   function renderArray(schemaInput) {
+    /**
+     * TODO: if caution tag is enabled, maybe additionalItems keyword
+     *       should be passed down to createNormalRow() even if in object form
+     */
     const { additionalItems, ...addItemsKeyExcluded } = schemaInput;
     const openArrayRow =
       typeof schemaInput.additionalItems === 'object'


### PR DESCRIPTION
**Closes Issue** #22 
fix right panel's display of keywords correctly

**Applied Changes**
- [x] `type` should be removed from right panel
   - [x] re-adjust blank line paddings in left panel to align lines between left and right panel

- [x] make boolean values displayable (in string form): `additionalItems`, `additionalProperties`, etc.
- [x] enum should display list of possible elements separately