### PR TITLE
Revert "Revert "Create renderArray() method" merge"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "prop-types": "^15.7.2"
   }
 }

--- a/schemas/basicDataTypes/array/additionalItems.json
+++ b/schemas/basicDataTypes/array/additionalItems.json
@@ -1,12 +1,14 @@
 {
-    "type": "array",
-    "items": [
-      {
-        "type": "number"
-      },
-      {
-        "type": "string"
-      }
-    ],
-    "additionalItems": { "type": "boolean" }
+  "type": "array",
+  "items": [
+    {
+      "type": "number"
+    },
+    {
+      "type": "string"
+    }
+  ],
+  "additionalItems": {
+    "type": "boolean"
   }
+}

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -1,47 +1,80 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
 
 function NormalLeftRow({ schema, classes }) {
-  const name = 'name' in schema ? `${schema.name}: ` : null;
-  const typeSymbol =
-    schema.type === 'array' || schema.type === 'object' ? (
-      {
-        array: '[',
-        object: '{',
-      }[schema.type]
-    ) : (
-      <code className={classes.code}>{schema.type}</code>
-    );
-  /** Create blank line paddings only for additional keywords that
-   *  will have their own lines on the according right row.
-   *  This enables the left row to have matching number of lines with
-   *  the right row and align the lines and heights between the two rows.
+  /**
+   * If schema or sub-schema has a name keyword,
+   * (ex. properties of object) store in variable to display.
    */
-  const nonPaddedKeywords = ['type', 'description', 'name'];
+  const name = 'name' in schema ? schema.name : null;
+  /** Map schema's type to a symbol for display. */
+  const typeSymbol = {
+    array: '[',
+    boolean: '"..."',
+    integer: '"..."',
+    null: '"..."',
+    number: '"..."',
+    object: '{',
+    string: '"..."',
+  }[schema.type];
+  /**
+   * Create blank line paddings only for additional keywords that
+   * will have their own lines on the according right row.
+   * This enables the left row to have matching number of lines with
+   * the right row and align the lines and heights between the two rows.
+   */
+  const nonPaddedKeywords = [
+    'type',
+    'description',
+    'name',
+    'items',
+    'contains',
+  ];
   const blankLinePaddings = [];
 
   Object.keys(schema).forEach(keyword => {
     if (!nonPaddedKeywords.includes(keyword)) {
-      blankLinePaddings.push(<br key={keyword} className={classes.line} />);
+      blankLinePaddings.push(
+        <Typography
+          key={`${keyword} line`}
+          component="div"
+          variant="subtitle2"
+          className={classes.line}>
+          <br />
+        </Typography>
+      );
     }
   });
 
   return (
-    <div className={classes.row}>
-      <p className={classes.line}>
-        {name}
+    <div key={schema.type} className={classes.row}>
+      <Typography component="div" variant="subtitle2" className={classes.line}>
+        {name && `${name}: `}
         {typeSymbol}
-      </p>
+      </Typography>
       {blankLinePaddings}
     </div>
   );
 }
 
 NormalLeftRow.propTypes = {
+  /**
+   * Schema input given to render.
+   * May also be a sub-schema in case for array items,
+   * object properties or more complex schemas.
+   */
   schema: shape({
+    /** Type of schema or sub-schema */
     type: string.isRequired,
+    /** Name of schema or sub-schema */
     name: string,
   }).isRequired,
+  /**
+   * Style for rows and lines for schema viewer.
+   * Necessary to maintain consistency with right panel's
+   * rows and lines.
+   */
   classes: shape({
     row: string.isRequired,
     line: string.isRequired,

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,37 +1,73 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
 
 function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema);
+  const nonDisplayedKeywords = ['items', 'contains'];
+
+  // TODO: specify details to see below?
+  /*
+  if (typeof schema.additionalItems === 'object') {
+  }
+  */
 
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>
-        {keywords.map(keyword => (
-          <p key={keyword} className={classes.line}>
-            {keyword}
-            {': '}
-            {schema[keyword]}
-          </p>
-        ))}
+        {keywords.map(
+          keyword =>
+            !nonDisplayedKeywords.includes(keyword) && (
+              <Typography
+                key={keyword}
+                component="div"
+                variant="subtitle2"
+                className={classes.line}>
+                {keyword}
+                {': '}
+                {schema[keyword]}
+              </Typography>
+            )
+        )}
       </div>
       <div className={classes.descriptionColumn}>
-        {'description' in schema && <p>{schema.description}</p>}
+        {'description' in schema && (
+          <Typography component="div" variant="subtitle2">
+            {schema.description}
+          </Typography>
+        )}
       </div>
     </div>
   );
 }
 
 NormalRightRow.propTypes = {
+  /**
+   * Schema input given to render.
+   * May also be a sub-schema in case for array items,
+   * object properties or more complex schemas.
+   */
   schema: shape({
+    /** Type of schema or sub-schema */
     type: string.isRequired,
   }).isRequired,
+  /**
+   * Style for rows and lines for schema viewer.
+   * Necessary to maintain consistency with right panel's
+   * rows and lines.
+   */
   classes: shape({
     row: string.isRequired,
-    rightRow: string.isRequired,
-    keywordColumn: string.isRequired,
-    descriptionColumn: string.isRequired,
     line: string.isRequired,
+    /**
+     * Display the right panel in a two-column grid
+     * : keywordColumn, descriptionColumn
+     */
+    rightRow: string.isRequired,
+    /** Column to display keywords for the schema or sub-schema */
+    keywordColumn: string.isRequired,
+    /** Column to display description for the schema or sub-schema */
+    descriptionColumn: string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -1,6 +1,38 @@
-SchemaTable example:
-
+### Default Type Schema
 ```js
 const schema = require('../../../schemas/basicDataTypes/string/stringPattern.json');
 <SchemaTable schema={schema} />
 ```
+
+### Array Type Schema
+
+list validation
+```js
+const schema = require('../../../schemas/basicDataTypes/array/listValidation.json');
+<SchemaTable schema={schema} />
+```
+
+tuple validation
+```js
+const schema = require('../../../schemas/basicDataTypes/array/tupleValidation.json');
+<SchemaTable schema={schema} />
+```
+
+additional items (defined as schema)
+```js
+const schema = require('../../../schemas/basicDataTypes/array/additionalItems.json');
+<SchemaTable schema={schema} />
+```
+
+contains keyword
+```js
+const schema = require('../../../schemas/basicDataTypes/array/containsValidation.json');
+<SchemaTable schema={schema} />
+```
+
+empty array
+```js
+const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
+<SchemaTable schema={schema} />
+```
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@4.2.x, clean-css@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"


### PR DESCRIPTION
Reverts taskcluster/material-ui-json-schema-viewer#27 (Revert "Create renderArray() method" merge)

**Result**
reverts back to status where #17 is merged into `master` branch (and also which is where some changes made in #25 are mistakenly overridden)

**Reasoning**
Initially, #27 was created to revert the merge of #17 (since #17 overrode some changes created in #25 and thus, changes of #25 were not applied to the master branch).

But since the changes in #25 are relatively small (just a few lines of code), it seems more efficient to revert back to the original state (where changes were overridden) and just simply apply the few lines of code instead. This helps to avoid over-complicating the commit history while still maintaining the overall changes made from #17 and #25.
