### PR TITLE
Create renderObject() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@material-ui/core": "^4.7.1",
+    "@material-ui/icons": "^4.5.1",
     "@mozilla-frontend-infra/react-lint": "^2.0.1",
     "@neutrinojs/jest": "9.0.0-rc.5",
     "@neutrinojs/react-components": "9.0.0-rc.5",
@@ -35,6 +36,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.7.1",
+    "@material-ui/icons": "^4.5.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "ramda": "^0.26.1"
   }
 }

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -3,7 +3,7 @@ import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 function NormalLeftRow({ schema, classes }) {
-  const name = 'name' in schema ? `${schema.name}: ` : null;
+  const name = 'name' in schema ? schema.name : null;
   const typeSymbol =
     schema.type === 'array' || schema.type === 'object' ? (
       {

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -15,13 +15,20 @@ function NormalLeftRow({ schema, classes }) {
     );
   /**
    * Create blank line paddings only for additional keywords
-   * (skip keywords which are not displayed in NormalRightRow)
+   * (skip over certain keywords not displayed in NormalRightRow)
    * that will have their own lines on the according right row.
    * This enables the left row to have matching number of lines with
    * the right row and align the lines and heights between the two rows.
    */
   const blankLinePaddings = [];
-  const skipKeywords = ['type', 'name', 'description', 'items', 'contains', 'properties'];
+  const skipKeywords = [
+    'type',
+    'name',
+    'description',
+    'items',
+    'contains',
+    'properties',
+  ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -21,7 +21,7 @@ function NormalLeftRow({ schema, classes }) {
    * the right row and align the lines and heights between the two rows.
    */
   const blankLinePaddings = [];
-  const skipKeywords = ['type', 'description', 'name', 'items', 'contains'];
+  const skipKeywords = ['type', 'name', 'description', 'items', 'contains', 'properties'];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -8,7 +8,7 @@ function NormalRightRow({ schema, classes }) {
    * : either in symbols in the left panel or in the description column.
    *   (ex. 'type' is displayed in highlighted form in left panel)
    */
-  const skipKeywords = ['type', 'name', 'description', 'items', 'contains'];
+  const skipKeywords = ['type', 'name', 'description', 'items', 'contains', 'properties'];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,14 +1,23 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
+import Tooltip from '@material-ui/core/Tooltip';
+import Warning from '@material-ui/icons/Info';
 
 function NormalRightRow({ schema, classes }) {
   /**
-   * Skip keywords illustrated in other parts of the SchemaTable
-   * : either in symbols in the left panel or in the description column.
-   *   (ex. 'type' is displayed in highlighted form in left panel)
+   * Skip over certain keywords illustrated in other parts of
+   * the SchemaTable to avoid displaying them repeatedly.
+   * (ex. symbols in the left panel or description in right panel)
    */
-  const skipKeywords = ['type', 'name', 'description', 'items', 'contains', 'properties'];
+  const skipKeywords = [
+    'type',
+    'name',
+    'description',
+    'items',
+    'contains',
+    'properties',
+  ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );
@@ -30,9 +39,20 @@ function NormalRightRow({ schema, classes }) {
               component="div"
               variant="subtitle2"
               className={classes.line}>
-              {keyword}
-              {': '}
-              {`${schema[keyword]}`}
+              {typeof schema[keyword] === 'object' &&
+              !Array.isArray(schema[keyword]) ? (
+                <Tooltip
+                  title="Additional items must match a sub-schema. 
+                  See the JSON-schema source for details."
+                  arrow>
+                  <Typography component="span" variant="subtitle">
+                    {`${keyword}: `}
+                    <Warning fontSize="inherit" color="inherit" />
+                  </Typography>
+                </Tooltip>
+              ) : (
+                `${keyword}: ${schema[keyword]}`
+              )}
             </Typography>
           ))
         )}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -21,6 +21,23 @@ function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );
+  /**
+   * Generate tooltip descriptions to provide further information
+   * regarding the given keywords.
+   * (only keywords defined as complex object types will need
+   *  tooltip descriptions)
+   */
+  const tooltipDescriptions = {
+    additionalItems: 'Additional items must match a sub-schema',
+    additionalProperties: 'Additional properties must match a sub-schema',
+    dependencies:
+      'The schema of the object may change based on the presence of certain special properties',
+    propertyNames: 'Names of properties must follow a specified convention',
+    patternProperties:
+      'Property names or values should match the specified pattern',
+  };
+  const createTooltipTitle = key =>
+    `${tooltipDescriptions[key]}. See the JSON-schema source for details.`;
 
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
@@ -41,11 +58,8 @@ function NormalRightRow({ schema, classes }) {
               className={classes.line}>
               {typeof schema[keyword] === 'object' &&
               !Array.isArray(schema[keyword]) ? (
-                <Tooltip
-                  title="Additional items must match a sub-schema. 
-                  See the JSON-schema source for details."
-                  arrow>
-                  <Typography component="span" variant="subtitle">
+                <Tooltip title={createTooltipTitle(keyword)} arrow>
+                  <Typography component="span" variant="subtitle2">
                     {`${keyword}: `}
                     <Warning fontSize="inherit" color="inherit" />
                   </Typography>

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -43,3 +43,9 @@ simple object
 const schema = require('../../../schemas/basicDataTypes/object/simpleObject.json');
 <SchemaTable schema={schema} />
 ```
+
+empty object
+```js
+const schema = require('../../../schemas/basicDataTypes/object/emptyObject.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -49,3 +49,15 @@ empty object
 const schema = require('../../../schemas/basicDataTypes/object/emptyObject.json');
 <SchemaTable schema={schema} />
 ```
+
+property specifications (names, patterns, additional subschemas)
+```js
+const schema = require('../../../schemas/basicDataTypes/object/propertySpecifications.json');
+<SchemaTable schema={schema} />
+```
+
+property dependencies
+```js
+const schema = require('../../../schemas/basicDataTypes/object/propertyDependencies.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -36,3 +36,10 @@ const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
 <SchemaTable schema={schema} />
 ```
 
+## Object Type Schema
+
+simple object
+```js
+const schema = require('../../../schemas/basicDataTypes/object/simpleObject.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -142,15 +142,7 @@ function SchemaTable({ schema }) {
    * added sequentially in between the opening and closing rows.
    */
   function renderArray(schemaInput) {
-    /**
-     * TODO: if caution tag is enabled, maybe additionalItems keyword
-     *       should be passed down to createNormalRow() even if in object form
-     */
-    const { additionalItems, ...addItemsKeyExcluded } = schemaInput;
-    const openArrayRow =
-      typeof schemaInput.additionalItems === 'object'
-        ? createNormalRow(addItemsKeyExcluded)
-        : createNormalRow(schemaInput);
+    const openArrayRow = createNormalRow(schemaInput);
     const closeArrayRow = createClosingRow(schemaInput.type);
 
     pushRow(openArrayRow);
@@ -178,16 +170,6 @@ function SchemaTable({ schema }) {
     /** Render contains keyword if defined */
     if ('contains' in schemaInput) {
       renderSchema(schemaInput.contains);
-    }
-
-    /**
-     * Add a extra row for additionalItems defined as schema.
-     * (If additionalItems is defined simply as a boolean value,
-     *  will be handled in openArrayRow's NormalRightRow instead)
-     */
-    if (typeof schemaInput.additionalItems === 'object') {
-      // TODO: alter the sub-schema to include extra description?
-      renderSchema(schemaInput.additionalItems);
     }
 
     pushRow(closeArrayRow);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { shape, string } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
+import { clone } from 'ramda';
 import Typography from '@material-ui/core/Typography';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
@@ -212,11 +213,38 @@ function SchemaTable({ schema }) {
   }
 
   /**
-   * TODO: define renderObject method
-   *       add description comment
+   * Object type schemas start with an openObjectRow and are closed off with
+   * a closeObjectRow, both displaying curly brackets to indicate an object.
+   * Object properties are parsed and rendered according to their type via
+   * calling back on the renderSchema() method. The resulting rows are
+   * added sequentially in between the opening and closing rows.
    */
   function renderObject(schemaInput) {
-    return <React.Fragment>{schemaInput}</React.Fragment>;
+    const openObjectRow = createNormalRow(schemaInput);
+    const closeObjectRow = createClosingRow(schemaInput.type);
+
+    pushRow(openObjectRow);
+
+    /** Render object properties only if defined */
+    if ('properties' in schemaInput) {
+      /**
+       * Render each of the property schemas sequentially.
+       * Make sure to create a name field for each of the properties'
+       * sub-schema so the names are also displayed in the left panel.
+       * (use cloned sub-schema to create new field in order to maintain
+       *  immutability of schema data)
+       */
+      const propertyList = Object.keys(schemaInput.properties);
+
+      propertyList.forEach(property => {
+        const cloneSubschema = clone(schemaInput.properties[property]);
+
+        cloneSubschema.name = property;
+        renderSchema(cloneSubschema);
+      });
+    }
+
+    pushRow(closeObjectRow);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
 
+"@material-ui/icons@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.5.1.tgz#6963bad139e938702ece85ca43067688018f04f8"
+  integrity sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.7.1.tgz#48fa70f06441c35e301a9c4b6c825526a97b7a29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7628,6 +7628,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
**Closes Issue** #14 & #30 
create a method to render object type schemas

**Applied Changes**
- [x] create object format in `SchemaTable`

    - [x] encapsulated between `[` and `]`

    - [x] each of the object properties should call on `renderSchema`

- [x] render exception cases: empty object schema
- [x] render complex definitions (see #30)
   - [x] `additionalProperties`

   - [x] `patternProperties`
   - [x] `propertyNames` 
   - [x] render `dependencies`

**Results**

<img src="https://user-images.githubusercontent.com/29671309/71437072-5f113500-2733-11ea-8a04-3d0d8b6c4ec1.png" width="500px" />
