### PR TITLE
Replace br tags in blank line paddings

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -34,7 +34,7 @@ function NormalLeftRow({ schema, classes }) {
           component="div"
           variant="subtitle2"
           className={classes.line}>
-          <br />
+          {null}
         </Typography>
       );
     }

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -21,7 +21,7 @@ function NormalRightRow({ schema, classes }) {
             component="div"
             variant="subtitle2"
             className={classes.line}>
-            <br />
+            {null}
           </Typography>
         ) : (
           keywords.map(keyword => (

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
   leftPanel: {
     backgroundColor: theme.palette.background.paper,
-    borderRight: `${theme.spacing(1)}px solid ${theme.palette.grey[300]}`,
+    borderRight: `${theme.spacing(1)}px solid ${theme.palette.divider}`,
     overflowX: 'auto',
   },
   rightPanel: {
@@ -22,7 +22,8 @@ const useStyles = makeStyles(theme => ({
     overflowX: 'auto',
   },
   row: {
-    borderBottom: `2px solid ${theme.palette.grey[300]}`,
+    borderBottom: `${theme.spacing(0.25)}px solid ${theme.palette.divider}`,
+    minHeight: theme.spacing(3),
   },
   lastRow: {
     borderBottom: 'none',
@@ -36,6 +37,7 @@ const useStyles = makeStyles(theme => ({
   line: {
     margin: 0,
     whiteSpace: 'nowrap',
+    minHeight: theme.spacing(3),
   },
   code: {
     backgroundColor: theme.palette.grey[300],
@@ -110,7 +112,7 @@ function SchemaTable({ schema }) {
               component="div"
               variant="subtitle2"
               className={classes.line}>
-              <br />
+              {null}
             </Typography>
           </div>
           <div className={classes.descriptionColumn}>


### PR DESCRIPTION
**Closes Issue**: #33 
replace `<br />` tags in blank line paddings

**Applied Changes**
- replaced br with null values
- adjusted min-height of rows and lines so that blank lines and rows align the heights between left and right panel

**Results**

<img src="https://user-images.githubusercontent.com/29671309/71436280-1dcb5600-2730-11ea-9e03-6e945c0c0b9a.png" width="700px" />
and
<img src="https://user-images.githubusercontent.com/29671309/71436306-2f146280-2730-11ea-80a2-cfd3d170cc9f.png" width="700px" />
