### PR TITLE
Add material-ui theme customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # material-ui-json-schema-viewer
-scaffolded project using [Neutrino](https://master.neutrinojs.org/packages/react-components/)
+a viewer component that displays JSON schemas
 
 ## Requirements
 - `@material-ui/core` v4+
 - `react` 16.8+
 - `react-dom` 16.8+
 
-## Override styles
-
-The default schema viewer appearance will inherit material-ui's default theme
-colors. You can change the theme by customizing the theme passed to
+## Theme Customization
+By default, the schema viewer inherits [material-ui's default theme](https://material-ui.com/customization/default-theme/). You can change the theme by customizing the theme passed to
 material-ui's [`ThemeProvider`](https://material-ui.com/styles/api/#themeprovider) component.
+You may also use material-ui's [`CSSBaseline`](https://material-ui.com/api/css-baseline/) to provide a more consistent style baseline as well.
+```js
+<CssBaseline />
+<ThemeProvider theme={customTheme}>
+    <SchemaTable />
+</ThemeProvider>
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # material-ui-json-schema-viewer
-a viewer component that displays JSON schemas
+a viewer component that displays JSON schemas (built using [material-ui](https://material-ui.com/))
 
 ## Requirements
 - `@material-ui/core` v4+

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -7,21 +7,25 @@ import Typography from '@material-ui/core/Typography';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
 
-// TODO: add comments for styles
 const useStyles = makeStyles(theme => ({
+  /** Schema table displays two-column layout */
   wrapper: {
     display: 'grid',
     gridTemplateColumns: '[left-panel] 1fr [right-panel] 1fr',
+    color: theme.palette.text.primary,
   },
+  /** The left panel of the Schema Table */
   leftPanel: {
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.default,
     borderRight: `${theme.spacing(1)}px solid ${theme.palette.divider}`,
     overflowX: 'auto',
   },
+  /** The right panel of the Schema Table */
   rightPanel: {
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.default,
     overflowX: 'auto',
   },
+  /** Rows for the left and right panels */
   row: {
     borderBottom: `${theme.spacing(0.25)}px solid ${theme.palette.divider}`,
     minHeight: theme.spacing(3),
@@ -29,17 +33,32 @@ const useStyles = makeStyles(theme => ({
   lastRow: {
     borderBottom: 'none',
   },
+  /**
+   * The right panel's rows are further divided into two columns
+   * : keyword column, description column
+   */
   rightRow: {
     display: 'grid',
     gridTemplateColumns: '[keyword-column] 1fr [description-column] 1fr',
   },
+  /** Column for displaying keywords for right panel's rows */
   keywordColumn: {},
+  /** Column for displaying description for right panel's rows */
   descriptionColumn: {},
+  /**
+   * Lines within the rows.
+   * (a single row may constitute of more than one line depending
+   *  on how many keywords the given schema or sub-schema defines)
+   */
   line: {
     margin: 0,
     whiteSpace: 'nowrap',
     minHeight: theme.spacing(3),
   },
+  /**
+   * Highlighting the type for the schema or sub-schema displayed
+   * in the left panel of the schema table component.
+   */
   code: {
     backgroundColor: theme.palette.grey[300],
   },

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,3 @@
+import SchemaTable from './SchemaTable';
+
+export default { SchemaTable };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import SchemaTable from './components/SchemaTable';
+import theme from './theme';
 
 const root = document.getElementById('root');
 
@@ -10,7 +11,7 @@ function App() {
   return (
     <Fragment>
       <CssBaseline />
-      <ThemeProvider>
+      <ThemeProvider theme={theme}>
         <SchemaTable />
       </ThemeProvider>
     </Fragment>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,10 +1,8 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React, { Fragment } from 'react';
 import { render } from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import SchemaTable from './components/SchemaTable';
-import theme from './theme';
 
 const root = document.getElementById('root');
 
@@ -12,7 +10,7 @@ function App() {
   return (
     <Fragment>
       <CssBaseline />
-      <ThemeProvider theme={theme}>
+      <ThemeProvider>
         <SchemaTable />
       </ThemeProvider>
     </Fragment>

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,3 +1,0 @@
-import { createMuiTheme } from '@material-ui/core/styles';
-
-export default createMuiTheme();

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,3 @@
+import { createMuiTheme } from '@material-ui/core/styles';	
+
+export default createMuiTheme();


### PR DESCRIPTION
**Closes Issue** #21 
enable `<SchemaTable />` component to accept custom themes to make the viewer customizable

**Applied Changes**
- ~refactored `<App />` into `<SchemaViewer />` which includes the stylization and theme customization for the schemaTable~
- ~added example of `<SchemaViewer />` with custom theme~
- added description for theme customization in `Readme.md`
- export `SchemaTable` component