### PR TITLE
Fix position of icon and highlighted text

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -36,13 +36,7 @@ function NormalLeftRow({ schema, classes }) {
   keywords.forEach((keyword, i) => {
     if (i > 0) {
       blankLinePaddings.push(
-        <Typography
-          key={`${keyword} line`}
-          component="div"
-          variant="subtitle2"
-          className={classes.line}>
-          {null}
-        </Typography>
+        <div key={`${keyword} line`} className={classes.line} />
       );
     }
   });

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -43,12 +43,7 @@ function NormalRightRow({ schema, classes }) {
     <div className={`${classes.row} ${classes.rightRow}`}>
       <div className={classes.keywordColumn}>
         {keywords.length === 0 ? (
-          <Typography
-            component="div"
-            variant="subtitle2"
-            className={classes.line}>
-            {null}
-          </Typography>
+          <div className={classes.line} />
         ) : (
           keywords.map(keyword => (
             <Typography

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -27,20 +27,20 @@ function NormalRightRow({ schema, classes }) {
         {keywords.length === 0 ? (
           <div className={classes.line} />
         ) : (
-          keywords.map(keyword => (
-            <Typography
-              key={keyword}
-              component="div"
-              variant="subtitle2"
-              className={classes.line}>
-              {typeof schema[keyword] === 'object' &&
+          keywords.map(keyword => {
+            return typeof schema[keyword] === 'object' &&
               !Array.isArray(schema[keyword]) ? (
-                <Tooltip keyword={keyword} />
-              ) : (
-                `${keyword}: ${schema[keyword]}`
-              )}
-            </Typography>
-          ))
+              <Tooltip keyword={keyword} classes={classes} />
+            ) : (
+              <Typography
+                key={keyword}
+                component="div"
+                variant="subtitle2"
+                className={classes.line}>
+                {`${keyword}: ${schema[keyword]}`}
+              </Typography>
+            );
+          })
         )}
       </div>
       <div className={classes.descriptionColumn}>

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -30,7 +30,7 @@ function NormalRightRow({ schema, classes }) {
           keywords.map(keyword => {
             return typeof schema[keyword] === 'object' &&
               !Array.isArray(schema[keyword]) ? (
-              <Tooltip keyword={keyword} classes={classes} />
+              <Tooltip key={keyword} keyword={keyword} classes={classes} />
             ) : (
               <Typography
                 key={keyword}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import Tooltip from '@material-ui/core/Tooltip';
-import Warning from '@material-ui/icons/Info';
+import Tooltip from '../Tooltip';
 
 function NormalRightRow({ schema, classes }) {
   /**
@@ -21,23 +20,6 @@ function NormalRightRow({ schema, classes }) {
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );
-  /**
-   * Generate tooltip descriptions to provide further information
-   * regarding the given keywords.
-   * (only keywords defined as complex object types will need
-   *  tooltip descriptions)
-   */
-  const tooltipDescriptions = {
-    additionalItems: 'Additional items must match a sub-schema',
-    additionalProperties: 'Additional properties must match a sub-schema',
-    dependencies:
-      'The schema of the object may change based on the presence of certain special properties',
-    propertyNames: 'Names of properties must follow a specified convention',
-    patternProperties:
-      'Property names or values should match the specified pattern',
-  };
-  const createTooltipTitle = key =>
-    `${tooltipDescriptions[key]}. See the JSON-schema source for details.`;
 
   return (
     <div className={`${classes.row} ${classes.rightRow}`}>
@@ -53,12 +35,7 @@ function NormalRightRow({ schema, classes }) {
               className={classes.line}>
               {typeof schema[keyword] === 'object' &&
               !Array.isArray(schema[keyword]) ? (
-                <Tooltip title={createTooltipTitle(keyword)} arrow>
-                  <Typography component="span" variant="subtitle2">
-                    {`${keyword}: `}
-                    <Warning fontSize="inherit" color="inherit" />
-                  </Typography>
-                </Tooltip>
+                <Tooltip keyword={keyword} />
               ) : (
                 `${keyword}: ${schema[keyword]}`
               )}

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -65,10 +65,17 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.grey[300],
     padding: `0 ${theme.spacing(0.5)}px`,
   },
+  /**
+   * The text and icon within Tooltip component should maintain
+   * a consistent line height and font size to align vertically.
+   */
   tooltip: {
     fontSize: `${theme.typography.subtitle2.fontSize}`,
     lineHeight: 1,
-    border: '1px red solid', // TODO: remove border
+  },
+  /** Icon within Tooltip component */
+  icon: {
+    margin: `0 ${theme.spacing(0.5)}px`,
   },
 }));
 

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -128,12 +128,7 @@ function SchemaTable({ schema }) {
           key={`close ${type}`}
           className={classNames(classes.row, classes.rightRow)}>
           <div className={classes.keywordColumn}>
-            <Typography
-              component="div"
-              variant="subtitle2"
-              className={classes.line}>
-              {null}
-            </Typography>
+            <div className={classes.line} />
           </div>
           <div className={classes.descriptionColumn}>
             <Typography component="div" variant="subtitle2" />

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -66,7 +66,9 @@ const useStyles = makeStyles(theme => ({
     padding: `0 ${theme.spacing(0.5)}px`,
   },
   tooltip: {
-    height: '100%',
+    fontSize: `${theme.typography.subtitle2.fontSize}`,
+    lineHeight: 1,
+    border: '1px red solid', // TODO: remove border
   },
 }));
 

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -51,9 +51,11 @@ const useStyles = makeStyles(theme => ({
    *  on how many keywords the given schema or sub-schema defines)
    */
   line: {
+    display: 'flex',
+    alignItems: 'center',
     margin: 0,
     whiteSpace: 'nowrap',
-    minHeight: theme.spacing(3),
+    height: theme.spacing(3.5),
   },
   /**
    * Highlighting the type for the schema or sub-schema displayed
@@ -61,6 +63,10 @@ const useStyles = makeStyles(theme => ({
    */
   code: {
     backgroundColor: theme.palette.grey[300],
+    padding: `0 ${theme.spacing(0.5)}px`,
+  },
+  tooltip: {
+    height: '100%',
   },
 }));
 

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { string } from 'prop-types';
+import MuiTooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import Warning from '@material-ui/icons/Info';
+
+function Tooltip({ keyword }) {
+  /**
+   * Generate tooltip descriptions to provide further information
+   * regarding the given keywords.
+   * (only keywords defined as complex object types will need
+   *  tooltip descriptions)
+   */
+  const tooltipDescriptions = {
+    additionalItems: 'Additional items must match a sub-schema',
+    additionalProperties: 'Additional properties must match a sub-schema',
+    dependencies:
+      'The schema of the object may change based on the presence of certain special properties',
+    propertyNames: 'Names of properties must follow a specified convention',
+    patternProperties:
+      'Property names or values should match the specified pattern',
+  };
+  const createTooltipTitle = key =>
+    `${tooltipDescriptions[key]}. See the JSON-schema source for details.`;
+
+  return (
+    <MuiTooltip title={createTooltipTitle(keyword)} arrow>
+      <Typography component="span" variant="subtitle2">
+        {`${keyword}: `}
+        <Warning fontSize="inherit" color="inherit" />
+      </Typography>
+    </MuiTooltip>
+  );
+}
+
+Tooltip.propTypes = {
+  /** Keyword to display with tooltip feature */
+  keyword: string.isRequired,
+};
+
+export default React.memo(Tooltip);

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
+import classNames from 'classnames';
 import MuiTooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import InfoIcon from '@material-ui/icons/Info';
@@ -30,12 +31,12 @@ function Tooltip({ keyword, classes }) {
           component="div"
           variant="subtitle2"
           className={classes.tooltip}>
-          {`${keyword}: `}
+          {keyword}
         </Typography>
         <InfoIcon
           fontSize="inherit"
           color="inherit"
-          className={classes.tooltip}
+          className={classNames(classes.tooltip, classes.icon)}
         />
       </div>
     </MuiTooltip>
@@ -45,9 +46,10 @@ function Tooltip({ keyword, classes }) {
 Tooltip.propTypes = {
   /** Keyword to display with tooltip feature */
   keyword: string.isRequired,
-  /** Style for icon display */
+  /** Style for tooltip and icon display */
   classes: shape({
     tooltip: string.isRequired,
+    icon: string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { string } from 'prop-types';
+import { shape, string } from 'prop-types';
 import MuiTooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import Warning from '@material-ui/icons/Info';
+import InfoIcon from '@material-ui/icons/Info';
 
-function Tooltip({ keyword }) {
+function Tooltip({ keyword, classes }) {
   /**
    * Generate tooltip descriptions to provide further information
    * regarding the given keywords.
@@ -25,9 +25,13 @@ function Tooltip({ keyword }) {
 
   return (
     <MuiTooltip title={createTooltipTitle(keyword)} arrow>
-      <Typography component="span" variant="subtitle2">
+      <Typography component="div" variant="subtitle2" className={classes.line}>
         {`${keyword}: `}
-        <Warning fontSize="inherit" color="inherit" />
+        <InfoIcon
+          fontSize="inherit"
+          color="inherit"
+          className={classes.tooltip}
+        />
       </Typography>
     </MuiTooltip>
   );
@@ -36,6 +40,10 @@ function Tooltip({ keyword }) {
 Tooltip.propTypes = {
   /** Keyword to display with tooltip feature */
   keyword: string.isRequired,
+  /** Style for icon display */
+  classes: shape({
+    tooltip: string.isRequired,
+  }).isRequired,
 };
 
 export default React.memo(Tooltip);

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -25,14 +25,19 @@ function Tooltip({ keyword, classes }) {
 
   return (
     <MuiTooltip title={createTooltipTitle(keyword)} arrow>
-      <Typography component="div" variant="subtitle2" className={classes.line}>
-        {`${keyword}: `}
+      <div className={classes.line}>
+        <Typography
+          component="div"
+          variant="subtitle2"
+          className={classes.tooltip}>
+          {`${keyword}: `}
+        </Typography>
         <InfoIcon
           fontSize="inherit"
           color="inherit"
           className={classes.tooltip}
         />
-      </Typography>
+      </div>
     </MuiTooltip>
   );
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,3 +1,3 @@
-import { createMuiTheme } from '@material-ui/core/styles';	
+import { createMuiTheme } from '@material-ui/core/styles';
 
 export default createMuiTheme();


### PR DESCRIPTION
**Closes Issue** #36 
- vertically center the icon with the tooltip text
- replace blanklines Typography component with div element
- add more padding to highlighted text and fix font-size and position if necessary

**Applied Changes**
- replaced blanklines Typography component with div element
- refactored `<Tooltip />` into its own separate component
- vertically centered the icon for the tooltip text
- fixed height or rows and lines + added padding for highlighted text (for `types` in left panel)

**Result Screenshot**

<img src="https://user-images.githubusercontent.com/29671309/71441552-427df880-2745-11ea-8020-519ff2d1a366.png" width="500px" />
