### PR TITLE
Add build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ typings/
 .env
 
 # build directory
-lib
+build
 
 # styleguide build directory
 styleguide


### PR DESCRIPTION
`yarn build` outputs artifacts in `build/` rather than `lib/`.