### PR TITLE
Apply indentations and prefix to nested structures

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -15,7 +15,16 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function NormalLeftRow({ schema, classes, indent }) {
+  /** 
+   * Dynamically generate indent styles according to the given
+   * indent props.
+   */
   const styles = useStyles(indent);
+  /** 
+   * Define the name to illustrate the schema or sub-schema.
+   * If a name property is not defined within the schema, 
+   * set it to null in order to not display any name.
+   */
   const name = 'name' in schema ? schema.name : null;
   /**
    * Define the type symbol for the schema or sub-schema's type
@@ -33,7 +42,10 @@ function NormalLeftRow({ schema, classes, indent }) {
   ) : (
     <code className={classes.code}>{schema.type}</code>
   );
-  // TODO: add 'contains' prefix
+  /** 
+   * Define the required prefix (* symbol) if the schema type
+   * is a required property of an object.
+  */
   const requiredPrefix =
     'required' in schema && schema.required === true ? (
       <span className={classes.requiredPrefix}>*</span>

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -15,14 +15,14 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function NormalLeftRow({ schema, classes, indent }) {
-  /** 
+  /**
    * Dynamically generate indent styles according to the given
    * indent props.
    */
   const styles = useStyles(indent);
-  /** 
+  /**
    * Define the name to illustrate the schema or sub-schema.
-   * If a name property is not defined within the schema, 
+   * If a name property is not defined within the schema,
    * set it to null in order to not display any name.
    */
   const name = 'name' in schema ? schema.name : null;
@@ -42,13 +42,17 @@ function NormalLeftRow({ schema, classes, indent }) {
   ) : (
     <code className={classes.code}>{schema.type}</code>
   );
-  /** 
+  /**
    * Define the required prefix (* symbol) if the schema type
    * is a required property of an object.
-  */
+   */
   const requiredPrefix =
     'required' in schema && schema.required === true ? (
-      <span className={classes.requiredPrefix}>*</span>
+      <span className={classes.prefix}>*</span>
+    ) : null;
+  const containsPrefix =
+    'contains' in schema && schema.contains === true ? (
+      <span className={classes.prefix}>⊃</span>
     ) : null;
   /**
    * Create blank line paddings only for additional keywords
@@ -59,6 +63,8 @@ function NormalLeftRow({ schema, classes, indent }) {
    */
   const blankLinePaddings = [];
   const skipKeywords = [
+    '$id',
+    '$schema',
     'type',
     'name',
     'description',
@@ -85,6 +91,7 @@ function NormalLeftRow({ schema, classes, indent }) {
         component="div"
         variant="subtitle2"
         className={classNames(classes.line, styles.indentation)}>
+        {containsPrefix}
         {name && `${name}: `}
         {typeSymbol}
         {requiredPrefix}
@@ -115,7 +122,7 @@ NormalLeftRow.propTypes = {
     row: string.isRequired,
     line: string.isRequired,
     code: string.isRequired,
-    requiredPrefix: string.isRequired,
+    prefix: string.isRequired,
   }).isRequired,
   indent: number.isRequired,
 };

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -16,6 +16,7 @@ function NormalRightRow({ schema, classes }) {
     'items',
     'contains',
     'properties',
+    'required',
   ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -48,7 +48,10 @@ function NormalRightRow({ schema, classes }) {
       </div>
       <div className={classes.descriptionColumn}>
         {'description' in schema && (
-          <Typography component="div" variant="subtitle2">
+          <Typography
+            component="div"
+            variant="subtitle2"
+            className={classes.line}>
             {schema.description}
           </Typography>
         )}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -10,6 +10,8 @@ function NormalRightRow({ schema, classes }) {
    * (ex. symbols in the left panel or description in right panel)
    */
   const skipKeywords = [
+    '$id',
+    '$schema',
     'type',
     'name',
     'description',

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -61,3 +61,9 @@ property dependencies
 const schema = require('../../../schemas/basicDataTypes/object/requiredProperties.json');
 <SchemaTable schema={schema} />
 ```
+
+## Complex Nested Types
+```js
+const schema = require('../../../schemas/demo/list-clients-response.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -58,6 +58,6 @@ const schema = require('../../../schemas/basicDataTypes/object/propertySpecifica
 
 property dependencies
 ```js
-const schema = require('../../../schemas/basicDataTypes/object/propertyDependencies.json');
+const schema = require('../../../schemas/basicDataTypes/object/requiredProperties.json');
 <SchemaTable schema={schema} />
 ```

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -63,6 +63,14 @@ const useStyles = makeStyles(theme => ({
     padding: `0 ${theme.spacing(0.5)}px`,
   },
   /**
+   * Prefixes used to notate special properties of data types in
+   * lines of NormalLeftRow. (ex. 'required', 'contains' keywords)
+   */
+  prefix: {
+    color: theme.palette.error.main,
+    padding: `0 ${theme.spacing(0.5)}px}`,
+  },
+  /**
    * The text and icon within Tooltip component should maintain
    * a consistent line height and font size to align vertically.
    */
@@ -73,10 +81,6 @@ const useStyles = makeStyles(theme => ({
   /** Icon within Tooltip component */
   icon: {
     margin: `0 ${theme.spacing(0.5)}px`,
-  },
-  requiredPrefix: {
-    color: theme.palette.error.main,
-    padding: `0 ${theme.spacing(0.5)}px}`,
   },
 }));
 
@@ -120,7 +124,6 @@ function SchemaTable({ schema }) {
     };
   }
 
-  // TODO: refactor closeRow into using createNormalRow
   /**
    * Create a row to close off an array or object type schema.
    * The left row displays a closing bracket of the type while
@@ -181,9 +184,16 @@ function SchemaTable({ schema }) {
       }
     }
 
-    /** Render contains keyword if defined */
+    /**
+     * Render contains keyword if defined.
+     * (create a subschema with 'contains' key set to true in order to
+     *  use the contains symbol in NormalLeftRow)
+     */
     if ('contains' in schemaInput) {
-      renderSchema(schemaInput.contains, indent + 1);
+      const cloneSubschema = clone(schemaInput.contains);
+
+      cloneSubschema.contains = true;
+      renderSchema(cloneSubschema, indent + 1);
     }
 
     pushRow(closeArrayRow);


### PR DESCRIPTION
**Closes** #24 
apply indentations and prefix to nested structures

**Applied Changes**
- [x] add indentations
- [x] add `required` keyword prefix for objects: `*`
- [x] add `contains` keyword prefix for arrays: `⊃`
- [x] add example of array containing object to styleguide

**Result**

- `contains` keyword in array type
<img src="https://user-images.githubusercontent.com/29671309/71638219-8751e400-2c9d-11ea-945a-dd72fb4cd2d2.png" width="100%" />

- `required` properties in object type
<img src="https://user-images.githubusercontent.com/29671309/71620142-9a1bd880-2c0b-11ea-9861-5b37c08c3212.png" width="100%" />
