### PR TITLE
Create renderCombination() method

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -132,7 +132,7 @@ NormalLeftRow.propTypes = {
    */
   schema: shape({
     /** Type of schema or sub-schema */
-    type: string.isRequired,
+    type: string,
     /** Name of schema or sub-schema */
     name: string,
   }).isRequired,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -32,24 +32,31 @@ function NormalLeftRow({ schema, classes, indent }) {
    * Complex types (allOf, anyOf, oneOf, no) use comment notation,
    * while others use highlighted text to illustrate the data type.
    */
-  const bracketTypes = ['array', 'object', 'closeArray', 'closeObject'];
-  const combinationTypes = [
-    'allOf',
-    'anyOf',
-    'oneOf',
-    'not',
-    'and',
-    'or',
-    'nor',
-  ];
-  const typeSymbol =
-    bracketTypes.includes(schema.type) ||
-    combinationTypes.includes(schema.type) ? (
-      {
+  const typeSymbol = createTypeSymbol(schema.type);
+
+  function createTypeSymbol(type) {
+    const bracketTypes = ['array', 'object', 'closeArray', 'closeObject'];
+    const combinationTypes = [
+      'allOf',
+      'anyOf',
+      'oneOf',
+      'not',
+      'and',
+      'or',
+      'nor',
+    ];
+
+    if (bracketTypes.includes(type)) {
+      return {
         array: '[',
         object: '{',
         closeArray: ']',
         closeObject: '}',
+      }[type];
+    }
+
+    if (combinationTypes.includes(type)) {
+      const commentText = {
         allOf: '// All of',
         anyOf: '// Any of',
         oneOf: '// One of',
@@ -57,10 +64,14 @@ function NormalLeftRow({ schema, classes, indent }) {
         and: '// and',
         or: '// or',
         nor: '// nor',
-      }[schema.type]
-    ) : (
-      <code className={classes.code}>{schema.type}</code>
-    );
+      }[type];
+
+      return <span className={classes.comment}>{commentText}</span>;
+    }
+
+    return <code className={classes.code}>{schema.type}</code>;
+  }
+
   /**
    * Define the required prefix (* symbol) if the schema type
    * is a required property of an object.
@@ -145,6 +156,7 @@ NormalLeftRow.propTypes = {
     row: string.isRequired,
     line: string.isRequired,
     code: string.isRequired,
+    comment: string.isRequired,
     prefix: string.isRequired,
   }).isRequired,
   indent: number.isRequired,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -33,7 +33,15 @@ function NormalLeftRow({ schema, classes, indent }) {
    * while others use highlighted text to illustrate the data type.
    */
   const bracketTypes = ['array', 'object', 'closeArray', 'closeObject'];
-  const combinationTypes = ['allOf', 'anyOf', 'oneOf', 'not'];
+  const combinationTypes = [
+    'allOf',
+    'anyOf',
+    'oneOf',
+    'not',
+    'and',
+    'or',
+    'nor',
+  ];
   const typeSymbol =
     bracketTypes.includes(schema.type) ||
     combinationTypes.includes(schema.type) ? (
@@ -48,6 +56,7 @@ function NormalLeftRow({ schema, classes, indent }) {
         not: '// Not',
         and: '// and',
         or: '// or',
+        nor: '// nor',
       }[schema.type]
     ) : (
       <code className={classes.code}>{schema.type}</code>

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -28,20 +28,30 @@ function NormalLeftRow({ schema, classes, indent }) {
   const name = 'name' in schema ? schema.name : null;
   /**
    * Define the type symbol for the schema or sub-schema's type
-   * Types requiring nested structures use the according bracket symbol
+   * Types requiring nested structures use the according bracket symbol,
+   * Complex types (allOf, anyOf, oneOf, no) use comment notation,
    * while others use highlighted text to illustrate the data type.
    */
   const bracketTypes = ['array', 'object', 'closeArray', 'closeObject'];
-  const typeSymbol = bracketTypes.includes(schema.type) ? (
-    {
-      array: '[',
-      object: '{',
-      closeArray: ']',
-      closeObject: '}',
-    }[schema.type]
-  ) : (
-    <code className={classes.code}>{schema.type}</code>
-  );
+  const combinationTypes = ['allOf', 'anyOf', 'oneOf', 'not'];
+  const typeSymbol =
+    bracketTypes.includes(schema.type) ||
+    combinationTypes.includes(schema.type) ? (
+      {
+        array: '[',
+        object: '{',
+        closeArray: ']',
+        closeObject: '}',
+        allOf: '// All of',
+        anyOf: '// Any of',
+        oneOf: '// One of',
+        not: '// Not',
+        and: '// and',
+        or: '// or',
+      }[schema.type]
+    ) : (
+      <code className={classes.code}>{schema.type}</code>
+    );
   /**
    * Define the required prefix (* symbol) if the schema type
    * is a required property of an object.
@@ -72,6 +82,10 @@ function NormalLeftRow({ schema, classes, indent }) {
     'contains',
     'properties',
     'required',
+    'allOf',
+    'anyOf',
+    'oneOf',
+    'not',
   ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -72,7 +72,7 @@ NormalRightRow.propTypes = {
    */
   schema: shape({
     /** Type of schema or sub-schema */
-    type: string.isRequired,
+    type: string,
   }).isRequired,
   /**
    * Style for rows and lines for schema viewer.

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -19,6 +19,10 @@ function NormalRightRow({ schema, classes }) {
     'contains',
     'properties',
     'required',
+    'allOf',
+    'anyOf',
+    'oneOf',
+    'not',
   ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -36,7 +36,7 @@ const schema = require('../../../schemas/basicDataTypes/array/emptyArray.json');
 <SchemaTable schema={schema} />
 ```
 
-## Object Type Schema
+### Object Type Schema
 
 simple object
 ```js
@@ -62,8 +62,21 @@ const schema = require('../../../schemas/basicDataTypes/object/requiredPropertie
 <SchemaTable schema={schema} />
 ```
 
-## Complex Nested Types
+### Complex Nested Types
 ```js
 const schema = require('../../../schemas/demo/list-clients-response.json');
+<SchemaTable schema={schema} />
+```
+
+### Combination Types
+allOf
+```js
+const schema = require('../../../schemas/combinationTypes/allOf.json');
+<SchemaTable schema={schema} />
+```
+
+anyOf
+```js
+const schema = require('../../../schemas/combinationTypes/anyOf.json');
 <SchemaTable schema={schema} />
 ```

--- a/src/components/SchemaTable/README.md
+++ b/src/components/SchemaTable/README.md
@@ -80,3 +80,15 @@ anyOf
 const schema = require('../../../schemas/combinationTypes/anyOf.json');
 <SchemaTable schema={schema} />
 ```
+
+oneOf
+```js
+const schema = require('../../../schemas/combinationTypes/oneOf.json');
+<SchemaTable schema={schema} />
+```
+
+not
+```js
+const schema = require('../../../schemas/combinationTypes/not.json');
+<SchemaTable schema={schema} />
+```

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -214,27 +214,33 @@ function SchemaTable({ schema }) {
    */
   function renderCombination(schemaInput, indent) {
     const openCombRow = createNormalRow(schemaInput, indent);
+    const combType = schemaInput.type;
+    const optionIndent = indent + 1;
 
     pushRow(openCombRow);
 
-    /**  */
-    const combType = schemaInput.type;
-    const combOptionList = schemaInput[combType];
+    /** If combination type is 'not', render only one option */
+    if (combType === 'not') {
+      renderSchema(schemaInput[combType], optionIndent);
+    } else {
+      /**
+       * else, options are defined as an array.
+       * Render each of the option schemas sequentially.
+       */
+      const combOptionList = schemaInput[combType];
 
-    /** If options exist, render each of the option schemas sequentially. */
-    if (combOptionList.length > 0) {
       combOptionList.forEach((option, i) => {
         /**
          * If more than one option, create a row with 'or', 'and', 'nor'
          * in order to separate the options.
          */
         if (i > 0) {
-          const optionSeparatorRow = createLiteralRow(combType, indent + 1);
+          const optionSeparatorRow = createLiteralRow(combType, optionIndent);
 
           pushRow(optionSeparatorRow);
         }
 
-        renderSchema(option, indent + 1);
+        renderSchema(option, optionIndent);
       });
     }
   }

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -108,7 +108,7 @@ function SchemaTable({ schema }) {
     return {
       leftRow: (
         <NormalLeftRow
-          key={leftRows.length + 1}
+          key={`left-row-${leftRows.length + 1}`}
           schema={schemaInput}
           classes={classes}
           indent={indent}
@@ -116,7 +116,7 @@ function SchemaTable({ schema }) {
       ),
       rightRow: (
         <NormalRightRow
-          key={rightRows.length + 1}
+          key={`right-row-${rightRows.length + 1}`}
           schema={schemaInput}
           classes={classes}
         />
@@ -136,7 +136,7 @@ function SchemaTable({ schema }) {
       allOf: 'and',
       anyOf: 'or',
       oneOf: 'or',
-      not: 'and',
+      not: 'nor',
     }[type];
     const literalSchema = {
       type: literalType,
@@ -220,7 +220,13 @@ function SchemaTable({ schema }) {
       /**
        * Render each of the option schemas sequentially.
        */
-      combOptionList.forEach(option => {
+      combOptionList.forEach((option, i) => {
+        if (i > 0) {
+          const optionSeparatorRow = createLiteralRow(combType, indent + 1);
+
+          pushRow(optionSeparatorRow);
+        }
+
         renderSchema(option, indent + 1);
       });
     }

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -62,6 +62,9 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.grey[300],
     padding: `0 ${theme.spacing(0.5)}px`,
   },
+  comment: {
+    color: theme.palette.text.hint,
+  },
   /**
    * Prefixes used to notate special properties of data types in
    * lines of NormalLeftRow. (ex. 'required', 'contains' keywords)


### PR DESCRIPTION
Closes #32 
create a method to render combination type schemas (allOf, anyOf, oneOf, not)

**Applied Changes**
- [x] take schema as input and parse to input into leftRow and rightRow
   - [x] render `allOf`
   - [x] render `anyOf`
   - [x] render `oneOf`
   - [x] render `not`
- [x] add rows for `and`, `or`, `nor` to separate subschemas
- [x] add combination type examples to styleguide

**Results**

<img src="https://user-images.githubusercontent.com/29671309/71722408-009f3180-2e6c-11ea-8069-f3d7f3f8ae6e.png" width="100%" />
