### PR TITLE
Refactor skipKeywords constants from row components

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -13,6 +13,7 @@ module.exports = {
            */
           functions: false,
         }],
+        'import/prefer-default-export': ['off'],
       },
     }),
     reactComponents(),

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -3,6 +3,7 @@ import { shape, string, number } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
+import skipKeywords from '../../utils/constants';
 
 /**
  * Dynamically generate styles for indentations to be used for
@@ -92,21 +93,6 @@ function NormalLeftRow({ schema, classes, indent }) {
    * the right row and align the lines and heights between the two rows.
    */
   const blankLinePaddings = [];
-  const skipKeywords = [
-    '$id',
-    '$schema',
-    'type',
-    'name',
-    'description',
-    'items',
-    'contains',
-    'properties',
-    'required',
-    'allOf',
-    'anyOf',
-    'oneOf',
-    'not',
-  ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -3,7 +3,7 @@ import { shape, string, number } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
-import skipKeywords from '../../utils/constants';
+import { SKIP_KEYWORDS } from '../../utils/constants';
 
 /**
  * Dynamically generate styles for indentations to be used for
@@ -94,7 +94,7 @@ function NormalLeftRow({ schema, classes, indent }) {
    */
   const blankLinePaddings = [];
   const keywords = Object.keys(schema).filter(
-    key => !skipKeywords.includes(key)
+    key => !SKIP_KEYWORDS.includes(key)
   );
 
   keywords.forEach((keyword, i) => {

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -2,28 +2,13 @@ import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '../Tooltip';
+import skipKeywords from '../../utils/constants';
 
 function NormalRightRow({ schema, classes }) {
   /**
-   * Skip over certain keywords illustrated in other parts of
-   * the SchemaTable to avoid displaying them repeatedly.
-   * (ex. symbols in the left panel or description in right panel)
+   * Filter keywords that should be displayed in the right panel.
+   * (skip over keywords that are already displayed in other parts)
    */
-  const skipKeywords = [
-    '$id',
-    '$schema',
-    'type',
-    'name',
-    'description',
-    'items',
-    'contains',
-    'properties',
-    'required',
-    'allOf',
-    'anyOf',
-    'oneOf',
-    'not',
-  ];
   const keywords = Object.keys(schema).filter(
     key => !skipKeywords.includes(key)
   );

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '../Tooltip';
-import skipKeywords from '../../utils/constants';
+import { SKIP_KEYWORDS } from '../../utils/constants';
 
 function NormalRightRow({ schema, classes }) {
   /**
@@ -10,7 +10,7 @@ function NormalRightRow({ schema, classes }) {
    * (skip over keywords that are already displayed in other parts)
    */
   const keywords = Object.keys(schema).filter(
-    key => !skipKeywords.includes(key)
+    key => !SKIP_KEYWORDS.includes(key)
   );
 
   return (

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,24 @@
+/**
+ * Keywords used in schemas that will be skipped over when 
+ * creating lines for NormalLeftRow and NormalRightRow.
+ * These are typically skipped over since they are already 
+ * illustrated in other parts of the SchemaTable
+   (ex. symbols in the left panel)
+ */
+const skipKeywords = [
+  '$id',
+  '$schema',
+  'type',
+  'name',
+  'description',
+  'items',
+  'contains',
+  'properties',
+  'required',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not',
+];
+
+export default skipKeywords;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,7 +5,7 @@
  * illustrated in other parts of the SchemaTable
    (ex. symbols in the left panel)
  */
-const skipKeywords = [
+export const SKIP_KEYWORDS = [
   '$id',
   '$schema',
   'type',
@@ -20,5 +20,3 @@ const skipKeywords = [
   'oneOf',
   'not',
 ];
-
-export default skipKeywords;


### PR DESCRIPTION
Closes #44 
refactor `skipKeywords` inside `src/utils/constant.js`

**Applied changes**
- [x] define `skipKeywords` in file `src/utils/constant.js`
- [x] import `skipKeywords` in NormalLeftRow and NormalRightRow