### PR TITLE
Improve UI for keywords display in NormalRightRow

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -131,15 +131,18 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
     const specifications = Object.keys(schemaInput).filter(
       key => !SKIP_KEYWORDS.includes(key)
     );
-    /**
-     * If there are not descriptor keywords to display,
-     * there is no need for any blank line paddings.
-     */
     const lines = [];
 
-    if (descriptors.length === 0) {
-      return lines;
-    }
+    /**
+     * Create a blank line per 3 spec keywords since a single line may
+     * only contain a max of 3 spec keywords. Skip over the first group
+     * of keywords since the first line already exists (to specify 'type').
+     */
+    specifications.forEach((keyword, i) => {
+      if (i % 3 === 0 && i > 0) {
+        lines.push(<div key={`${keyword}-line`} className={classes.line} />);
+      }
+    });
 
     /** Create a blank line for each descriptor keyword. */
     descriptors.forEach((keyword, i) => {
@@ -148,7 +151,7 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
        * if specification keywords exists, a blank line should be added
        * to visually separate the specification line and descriptor line.
        * Else, no specifications exists, skip over the first descriptor
-       * keyword so that the lines match the number of lines in NormalRightRow
+       * since the first line already exists (to specify 'type').
        */
       if (i === 0) {
         if (specifications.length > 0) {

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -6,14 +6,13 @@ import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandIcon from '@material-ui/icons/ArrowRightRounded';
 import ShrinkIcon from '@material-ui/icons/ArrowDropDownRounded';
-import { treeNode } from '../../utils/prop-types';
+import { treeNode, NOOP } from '../../utils/prop-types';
 import { expandRefNode, shrinkRefNode } from '../../utils/schemaTree';
 import {
   SKIP_KEYWORDS,
   DESCRIPTIVE_KEYWORDS,
   COMBINATION_TYPES,
   NESTED_TYPES,
-  NOOP,
 } from '../../utils/constants';
 
 /**

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -79,7 +79,8 @@ function NormalRightRow({ classes, treeNode }) {
         key={keyword}
         component="div"
         variant="subtitle2"
-        className={classes.line}>
+        className={classes.line}
+        noWrap>
         {keyword === 'title' ? (
           <strong>{schema[keyword]}</strong>
         ) : (

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shape, string } from 'prop-types';
 import Chip from '@material-ui/core/Chip';
 import InfoIcon from '@material-ui/icons/Info';
+import { Typography } from '@material-ui/core';
 import Tooltip from '../Tooltip';
 import OverflowLine from '../OverflowLine';
 import { treeNode } from '../../utils/prop-types';
@@ -11,7 +12,6 @@ import {
   MAX_NUMBER_OF_CHIPS,
   TOOLTIP_DESCRIPTIONS,
 } from '../../utils/constants';
-import { Typography } from '@material-ui/core';
 
 function NormalRightRow({ classes, treeNode }) {
   const { schema } = treeNode;
@@ -152,13 +152,8 @@ function NormalRightRow({ classes, treeNode }) {
    * Display the descriptive keyword in a single line.
    */
   function createDescriptionLine(keyword) {
-
     return (
-      <OverflowLine
-        key={keyword}
-        classes={classes}
-        content={schema[keyword]}
-      />
+      <OverflowLine key={keyword} classes={classes} content={schema[keyword]} />
     );
   }
 
@@ -184,6 +179,7 @@ function NormalRightRow({ classes, treeNode }) {
      */
     if (specKeywords.length > 0) {
       const specLines = createSpecificationLines(specKeywords);
+
       lines = lines.concat(specLines);
     }
 
@@ -205,7 +201,7 @@ function NormalRightRow({ classes, treeNode }) {
         } else if (keyword === 'description') {
           lines.push(createDescriptionLine(keyword));
         }
-      })
+      });
     }
 
     return lines;

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -2,9 +2,14 @@ import React from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Chip from '@material-ui/core/Chip';
+import InfoIcon from '@material-ui/icons/Info';
 import Tooltip from '../Tooltip';
 import { treeNode } from '../../utils/prop-types';
-import { SKIP_KEYWORDS, DESCRIPTIVE_KEYWORDS } from '../../utils/constants';
+import {
+  SKIP_KEYWORDS,
+  DESCRIPTIVE_KEYWORDS,
+  TOOLTIP_DESCRIPTIONS,
+} from '../../utils/constants';
 
 function NormalRightRow({ classes, treeNode }) {
   const { schema } = treeNode;
@@ -24,12 +29,34 @@ function NormalRightRow({ classes, treeNode }) {
 
   /**
    * Display keywords defining specifications as chips.
-   * If keyword definition is too complex, display tooltip with info icon
-   * in order to inform users to refer to the source for more details.
    */
   function displaySpecKeyword(keyword) {
     /**
-     * Typecast the definition in string format to display properly.
+     * If keyword's property is defined complex, display the chip within
+     * a tooltip to inform users to refer to the source for more details.
+     */
+    if (
+      typeof schema[keyword] === 'object' &&
+      !Array.isArray(schema[keyword])
+    ) {
+      /** Generate tooltip descriptions to match the keyword. */
+      const tooltipTitle = `${TOOLTIP_DESCRIPTIONS[keyword]} See the JSON-schema source for details.`;
+      const infoIcon = <InfoIcon fontSize="inherit" color="inherit" />;
+
+      return (
+        <Tooltip key={keyword} title={tooltipTitle}>
+          <Chip
+            label={keyword}
+            icon={infoIcon}
+            size="small"
+            variant="outlined"
+          />
+        </Tooltip>
+      );
+    }
+
+    /**
+     * Typecast the keyword's property to string format for property display.
      */
     const keyValue = (function keyValueToString(key) {
       if (Array.isArray(schema[keyword])) {
@@ -49,16 +76,6 @@ function NormalRightRow({ classes, treeNode }) {
 
       return schema[key];
     })(keyword);
-
-    /**
-     * Display chip within tooltip for complex definitions.
-     */
-    if (
-      typeof schema[keyword] === 'object' &&
-      !Array.isArray(schema[keyword])
-    ) {
-      return <Tooltip key={keyword} keyword={keyword} classes={classes} />;
-    }
 
     return (
       <Chip

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -22,10 +22,9 @@ function NormalRightRow({ classes, treeNode }) {
   );
   /**
    * Identify keywords that help describe the given schema.
+   * (maintain order specified in DESCRIPTIVE_KEYWORDS)
    */
-  const descriptorKeywords = Object.keys(schema).filter(key =>
-    DESCRIPTIVE_KEYWORDS.includes(key)
-  );
+  const descriptorKeywords = DESCRIPTIVE_KEYWORDS.filter(key => key in schema);
 
   /**
    * Display keywords defining specifications as chips.
@@ -129,10 +128,12 @@ function NormalRightRow({ classes, treeNode }) {
 
     /**
      * If descriptive keywords exist, display each keyword in its own line.
-     * (if specification keywords also exist, create a blank line to separate
-     *  specifications line and lines for descriptions)
      */
     if (descriptors.length > 0) {
+      /**
+       * If specification keywords also exist, create a blank line to separate
+       * specifications line and lines for descriptions.
+       */
       if (specs.length > 0) {
         lines.push(<div key="separator-line" className={classes.line} />);
       }

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -99,7 +99,13 @@ function NormalRightRow({ classes, treeNode }) {
         schema[keyword]
       );
 
-    return <OverflowLine key={keyword} classes={classes} content={descriptorContent} />;
+    return (
+      <OverflowLine
+        key={keyword}
+        classes={classes}
+        content={descriptorContent}
+      />
+    );
   }
 
   /**
@@ -117,16 +123,35 @@ function NormalRightRow({ classes, treeNode }) {
     }
 
     /**
-     * If specification keywords exist, display each keyword as chip
-     * within a single line in alphabetic order.
+     * If specification keywords exist, display each keyword as a chip.
      */
     if (specs.length > 0) {
+      /**
+       * Group alphabetically sorted keywords in sizes of three
+       * so that a single line may only contain a max of 3 chips.
+       */
+      const specKeywordLines = [[]];
+
       specs.sort();
-      lines.push(
-        <div key="spec-line" className={classes.line}>
-          {specs.map(keyword => displaySpecKeyword(keyword))}
-        </div>
-      );
+      specs.forEach((keyword, i) => {
+        const lineIndex = Math.trunc(i / 3);
+
+        if (lineIndex > specKeywordLines.length - 1) {
+          specKeywordLines.push([]);
+        }
+
+        specKeywordLines[lineIndex].push(keyword);
+      });
+
+      specKeywordLines.forEach(keywordGroup => {
+        lines.push(
+          <div
+            key={`spec-line-${keywordGroup.toString()}`}
+            className={classes.line}>
+            {keywordGroup.map(keyword => displaySpecKeyword(keyword))}
+          </div>
+        );
+      });
     }
 
     /**

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -8,6 +8,7 @@ import { treeNode } from '../../utils/prop-types';
 import {
   SKIP_KEYWORDS,
   DESCRIPTIVE_KEYWORDS,
+  MAX_NUMBER_OF_CHIPS,
   TOOLTIP_DESCRIPTIONS,
 } from '../../utils/constants';
 
@@ -15,21 +16,23 @@ function NormalRightRow({ classes, treeNode }) {
   const { schema } = treeNode;
   /**
    * Identify keywords that define specifications of the given schema.
-   * (skip over keywords that do not need to be displayed)
+   * (skip over keywords that do not need to be displayed).
+   * Each keyword will be displayed as a chip.
    */
   const specKeywords = Object.keys(schema).filter(
     key => !SKIP_KEYWORDS.includes(key)
   );
   /**
    * Identify keywords that help describe the given schema.
-   * (maintain order specified in DESCRIPTIVE_KEYWORDS)
+   * (ensure to maintain order specified in DESCRIPTIVE_KEYWORDS)
    */
   const descriptorKeywords = DESCRIPTIVE_KEYWORDS.filter(key => key in schema);
 
   /**
-   * Display keywords defining specifications as chips.
+   * Create a chip to display keyword properties.
+   * This is used to display specification keywords.
    */
-  function displaySpecKeyword(keyword) {
+  function createKeywordChip(keyword) {
     /**
      * If keyword's property is defined complex, display the chip within
      * a tooltip to inform users to refer to the source for more details.
@@ -89,9 +92,50 @@ function NormalRightRow({ classes, treeNode }) {
   }
 
   /**
-   * Display a single descriptive keyword in its own line.
+   * Create lines for specification keywords in groups of chips.
+   * Each specification keyword is displayed as a chip and
+   * a single line may only contain a MAX_NUMBER_OF_CHIPS at most.
    */
-  function displayDescriptor(keyword) {
+  function createSpecificationLines(specKeywords) {
+    const lines = [];
+    /**
+     * Sort specification keywords in alphabetical order and
+     * group the keywords in sizes of MAX_NUMBER_OF_CHIPS.
+     */
+    const keywordGroups = [[]];
+
+    specKeywords.sort();
+    specKeywords.forEach((keyword, i) => {
+      const groupIndex = Math.trunc(i / MAX_NUMBER_OF_CHIPS);
+
+      if (groupIndex > keywordGroups.length - 1) {
+        keywordGroups.push([]);
+      }
+
+      keywordGroups[groupIndex].push(keyword);
+    });
+
+    /**
+     * Each keyword group displays a single line containing
+     * a MAX_NUMBER_OF_CHIPS amount of chips
+     */
+    keywordGroups.forEach(keywordGroup => {
+      lines.push(
+        <div
+          key={`spec-line-${keywordGroup.toString()}`}
+          className={classes.line}>
+          {keywordGroup.map(keyword => createKeywordChip(keyword))}
+        </div>
+      );
+    });
+
+    return lines;
+  }
+
+  /**
+   * Display the descriptive keyword in a single line.
+   */
+  function createDescriptionLine(keyword) {
     const descriptorContent =
       keyword === 'title' ? (
         <strong>{schema[keyword]}</strong>
@@ -109,64 +153,45 @@ function NormalRightRow({ classes, treeNode }) {
   }
 
   /**
-   * Create the lines to display in a single right row according
-   * to the schema's specification and descriptive keywords.
-   * @param {Array} specs specification keywords in schema
-   * @param {Array} descriptors descriptive keywords in schema
+   * Create lines for the schema's specification and descriptive keywords.
+   * @param {Array} specKeywords specification keywords in schema
+   * @param {Array} descriptorKeywords descriptive keywords in schema
+   * @returns {Array} lines for the schema's right panel
    */
-  function displayLines(specs, descriptors) {
-    const lines = [];
+  function createLinesForKeywords(specKeywords, descriptorKeywords) {
+    let lines = [];
 
-    /** If no keywords necessary, display a single blank line */
-    if (specs.length === 0 && descriptors.length === 0) {
+    /**
+     * If neither keyword types exist, display a single blank line
+     * to match the 'type' line in NormalLeftRow.
+     */
+    if (specKeywords.length === 0 && descriptorKeywords.length === 0) {
       lines.push(<div key="blank-line" className={classes.line} />);
     }
 
     /**
-     * If specification keywords exist, display each keyword as a chip.
+     * If specification keywords exist, create lines to hold keyword chips.
      */
-    if (specs.length > 0) {
-      /**
-       * Group alphabetically sorted keywords in sizes of three
-       * so that a single line may only contain a max of 3 chips.
-       */
-      const specKeywordLines = [[]];
-
-      specs.sort();
-      specs.forEach((keyword, i) => {
-        const lineIndex = Math.trunc(i / 3);
-
-        if (lineIndex > specKeywordLines.length - 1) {
-          specKeywordLines.push([]);
-        }
-
-        specKeywordLines[lineIndex].push(keyword);
-      });
-
-      specKeywordLines.forEach(keywordGroup => {
-        lines.push(
-          <div
-            key={`spec-line-${keywordGroup.toString()}`}
-            className={classes.line}>
-            {keywordGroup.map(keyword => displaySpecKeyword(keyword))}
-          </div>
-        );
-      });
+    if (specKeywords.length > 0) {
+      const specLines = createSpecificationLines(specKeywords);
+      lines = lines.concat(specLines);
     }
 
     /**
      * If descriptive keywords exist, display each keyword in its own line.
      */
-    if (descriptors.length > 0) {
+    if (descriptorKeywords.length > 0) {
       /**
        * If specification keywords also exist, create a blank line to separate
-       * specifications line and lines for descriptions.
+       * specification lines and lines for descriptions.
        */
-      if (specs.length > 0) {
+      if (specKeywords.length > 0) {
         lines.push(<div key="separator-line" className={classes.line} />);
       }
 
-      descriptors.forEach(keyword => lines.push(displayDescriptor(keyword)));
+      descriptorKeywords.forEach(keyword =>
+        lines.push(createDescriptionLine(keyword))
+      );
     }
 
     return lines;
@@ -174,7 +199,7 @@ function NormalRightRow({ classes, treeNode }) {
 
   return (
     <div className={classes.row}>
-      {displayLines(specKeywords, descriptorKeywords)}
+      {createLinesForKeywords(specKeywords, descriptorKeywords)}
     </div>
   );
 }

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -11,6 +11,7 @@ import {
   MAX_NUMBER_OF_CHIPS,
   TOOLTIP_DESCRIPTIONS,
 } from '../../utils/constants';
+import { Typography } from '@material-ui/core';
 
 function NormalRightRow({ classes, treeNode }) {
   const { schema } = treeNode;
@@ -133,21 +134,30 @@ function NormalRightRow({ classes, treeNode }) {
   }
 
   /**
+   * Display the title keyword in a single line.
+   */
+  function createTitleLine(keyword) {
+    return (
+      <Typography
+        className={classes.line}
+        component="div"
+        variant="subtitle2"
+        noWrap>
+        <strong>{schema[keyword]}</strong>
+      </Typography>
+    );
+  }
+
+  /**
    * Display the descriptive keyword in a single line.
    */
   function createDescriptionLine(keyword) {
-    const descriptorContent =
-      keyword === 'title' ? (
-        <strong>{schema[keyword]}</strong>
-      ) : (
-        schema[keyword]
-      );
 
     return (
       <OverflowLine
         key={keyword}
         classes={classes}
-        content={descriptorContent}
+        content={schema[keyword]}
       />
     );
   }
@@ -189,9 +199,13 @@ function NormalRightRow({ classes, treeNode }) {
         lines.push(<div key="separator-line" className={classes.line} />);
       }
 
-      descriptorKeywords.forEach(keyword =>
-        lines.push(createDescriptionLine(keyword))
-      );
+      descriptorKeywords.forEach(keyword => {
+        if (keyword === 'title') {
+          lines.push(createTitleLine(keyword));
+        } else if (keyword === 'description') {
+          lines.push(createDescriptionLine(keyword));
+        }
+      })
     }
 
     return lines;

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -105,6 +105,8 @@ function NormalRightRow({ classes, treeNode }) {
   /**
    * Create the lines to display in a single right row according
    * to the schema's specification and descriptive keywords.
+   * @param {Array} specs specification keywords in schema
+   * @param {Array} descriptors descriptive keywords in schema
    */
   function displayLines(specs, descriptors) {
     const lines = [];
@@ -116,9 +118,10 @@ function NormalRightRow({ classes, treeNode }) {
 
     /**
      * If specification keywords exist, display each keyword as chip
-     * within a single line.
+     * within a single line in alphabetic order.
      */
     if (specs.length > 0) {
+      specs.sort();
       lines.push(
         <div key="spec-line" className={classes.line}>
           {specs.map(keyword => displaySpecKeyword(keyword))}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback, Fragment } from 'react';
 import { shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Chip from '@material-ui/core/Chip';
@@ -39,7 +39,9 @@ function NormalRightRow({ classes, treeNode }) {
       typeof schema[keyword] === 'object' &&
       !Array.isArray(schema[keyword])
     ) {
-      /** Generate tooltip descriptions to match the keyword. */
+      /**
+       * Generate tooltip descriptions to match the keyword.
+       */
       const tooltipTitle = `${TOOLTIP_DESCRIPTIONS[keyword]} See the JSON-schema source for details.`;
       const infoIcon = <InfoIcon fontSize="inherit" color="inherit" />;
 
@@ -56,7 +58,7 @@ function NormalRightRow({ classes, treeNode }) {
     }
 
     /**
-     * Typecast the keyword's property to string format for property display.
+     * Typecast the keyword's property to string format for proper display.
      */
     const keyValue = (function keyValueToString(key) {
       if (Array.isArray(schema[keyword])) {
@@ -91,18 +93,49 @@ function NormalRightRow({ classes, treeNode }) {
    * Display a single descriptive keyword in its own line.
    */
   function displayDescriptor(keyword) {
+    /**
+     * Create a state and callback ref to track the component's
+     * width measurements. (using a callback ref ensures that
+     * changes to the current ref componen is notified)
+     */
+    const [isTextOverflow, setIsTextOverflow] = useState(false);
+    const measuredRef = useCallback(element => {
+      if (element !== null) {
+        if (element.scrollWidth > element.offsetWidth) {
+          setIsTextOverflow(true);
+        }
+      }
+    }, []);
+    const descriptorContent =
+      keyword === 'title' ? (
+        <strong>{schema[keyword]}</strong>
+      ) : (
+          schema[keyword]
+        );
+
+    if (isTextOverflow) {
+      return (
+        <Tooltip key={keyword} title={descriptorContent}>
+          <div className={classes.line}>
+            <Typography
+              component="div"
+              variant="subtitle2"
+              ref={measuredRef}
+              noWrap>
+              {descriptorContent}
+            </Typography>
+          </div>
+        </Tooltip>
+      );
+    }
     return (
       <Typography
         key={keyword}
         component="div"
         variant="subtitle2"
         className={classes.line}
-        noWrap>
-        {keyword === 'title' ? (
-          <strong>{schema[keyword]}</strong>
-        ) : (
-          schema[keyword]
-        )}
+        ref={measuredRef}>
+        {descriptorContent}
       </Typography>
     );
   }

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -100,7 +100,7 @@ function NormalRightRow({ classes, treeNode }) {
         schema[keyword]
       );
 
-    return <OverflowLine key={keyword} text={descriptorContent} />;
+    return <OverflowLine key={keyword} classes={classes} content={descriptorContent} />;
   }
 
   /**

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useCallback, Fragment } from 'react';
+import React from 'react';
 import { shape, string } from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import Chip from '@material-ui/core/Chip';
 import InfoIcon from '@material-ui/icons/Info';
 import Tooltip from '../Tooltip';
+import OverflowLine from '../OverflowLine';
 import { treeNode } from '../../utils/prop-types';
 import {
   SKIP_KEYWORDS,
@@ -93,51 +93,14 @@ function NormalRightRow({ classes, treeNode }) {
    * Display a single descriptive keyword in its own line.
    */
   function displayDescriptor(keyword) {
-    /**
-     * Create a state and callback ref to track the component's
-     * width measurements. (using a callback ref ensures that
-     * changes to the current ref componen is notified)
-     */
-    const [isTextOverflow, setIsTextOverflow] = useState(false);
-    const measuredRef = useCallback(element => {
-      if (element !== null) {
-        if (element.scrollWidth > element.offsetWidth) {
-          setIsTextOverflow(true);
-        }
-      }
-    }, []);
     const descriptorContent =
       keyword === 'title' ? (
         <strong>{schema[keyword]}</strong>
       ) : (
-          schema[keyword]
-        );
-
-    if (isTextOverflow) {
-      return (
-        <Tooltip key={keyword} title={descriptorContent}>
-          <div className={classes.line}>
-            <Typography
-              component="div"
-              variant="subtitle2"
-              ref={measuredRef}
-              noWrap>
-              {descriptorContent}
-            </Typography>
-          </div>
-        </Tooltip>
+        schema[keyword]
       );
-    }
-    return (
-      <Typography
-        key={keyword}
-        component="div"
-        variant="subtitle2"
-        className={classes.line}
-        ref={measuredRef}>
-        {descriptorContent}
-      </Typography>
-    );
+
+    return <OverflowLine key={keyword} text={descriptorContent} />;
   }
 
   /**
@@ -190,7 +153,7 @@ function NormalRightRow({ classes, treeNode }) {
 NormalRightRow.propTypes = {
   /**
    * Style for rows and lines for schema viewer.
-   * Necessary to maintain consistency with right panel's
+   * Necessary to maintain consistency with left panel's
    * rows and lines.
    */
   classes: shape({

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -66,10 +66,7 @@ OverflowLine.propTypes = {
   /**
    * Content to be displayed.
    */
-  content: oneOfType([
-    node,
-    string,
-  ]).isRequired,
+  content: oneOfType([node, string]).isRequired,
 };
 
 export default React.memo(OverflowLine);

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 import { shape, string, oneOfType, node } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '../Tooltip';
@@ -12,19 +12,15 @@ import Tooltip from '../Tooltip';
  * with detectin changes when the window size changes)
  */
 function OverflowLine({ classes, content }) {
-
   return (
     <Tooltip title={content}>
       <div className={classes.line}>
-        <Typography
-          component="div"
-          variant="subtitle2"
-          noWrap>
+        <Typography component="div" variant="subtitle2" noWrap>
           {content}
         </Typography>
       </div>
     </Tooltip>
-  )
+  );
 }
 
 OverflowLine.propTypes = {

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { shape, string } from 'prop-types';
+import { shape, string, oneOfType, node } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '../Tooltip';
 
@@ -8,7 +8,7 @@ import Tooltip from '../Tooltip';
  * If the content text overflows, returns a line component with
  * the text ellipsed and tooltip is used to display full text instead.
  */
-function OverflowLine({ classes, text }) {
+function OverflowLine({ classes, content }) {
   /**
    * Track the textOverflow state depending on the component's
    * width size relative to the text's length.
@@ -30,14 +30,14 @@ function OverflowLine({ classes, text }) {
 
   if (isTextOverflow) {
     return (
-      <Tooltip title={text}>
+      <Tooltip title={content}>
         <div className={classes.line}>
           <Typography
             component="div"
             variant="subtitle2"
             ref={measuredRef}
             noWrap>
-            {text}
+            {content}
           </Typography>
         </div>
       </Tooltip>
@@ -50,7 +50,7 @@ function OverflowLine({ classes, text }) {
       variant="subtitle2"
       className={classes.line}
       ref={measuredRef}>
-      {text}
+      {content}
     </Typography>
   );
 }
@@ -63,7 +63,13 @@ OverflowLine.propTypes = {
   classes: shape({
     line: string.isRequired,
   }).isRequired,
-  text: string.isRequired,
+  /**
+   * Content to be displayed.
+   */
+  content: oneOfType([
+    node,
+    string,
+  ]).isRequired,
 };
 
 export default React.memo(OverflowLine);

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useCallback } from 'react';
+import { shape, string } from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import Tooltip from '../Tooltip';
+
+/**
+ * A single line component within a row of the schemaTable.
+ * If the content text overflows, returns a line component with
+ * the text ellipsed and tooltip is used to display full text instead.
+ */
+function OverflowLine({ classes, text }) {
+  /**
+   * Track the textOverflow state depending on the component's
+   * width size relative to the text's length.
+   */
+  const [isTextOverflow, setIsTextOverflow] = useState(false);
+  /**
+   * Create a callback ref method to use to track the component's
+   * width measurements.
+   * (using a callback ref ensures that changes made to the ref
+   *  component can update the isTextOverflow state)
+   */
+  const measuredRef = useCallback(element => {
+    if (element !== null) {
+      if (element.scrollWidth > element.offsetWidth) {
+        setIsTextOverflow(true);
+      }
+    }
+  }, []);
+
+  if (isTextOverflow) {
+    return (
+      <Tooltip title={text}>
+        <div className={classes.line}>
+          <Typography
+            component="div"
+            variant="subtitle2"
+            ref={measuredRef}
+            noWrap>
+            {text}
+          </Typography>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Typography
+      component="div"
+      variant="subtitle2"
+      className={classes.line}
+      ref={measuredRef}>
+      {text}
+    </Typography>
+  );
+}
+
+OverflowLine.propTypes = {
+  /**
+   * Style for lines for schema viewer.
+   * Necessary to maintain consistency within the schema table.
+   */
+  classes: shape({
+    line: string.isRequired,
+  }).isRequired,
+  text: string.isRequired,
+};
+
+export default React.memo(OverflowLine);

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -4,55 +4,27 @@ import Typography from '@material-ui/core/Typography';
 import Tooltip from '../Tooltip';
 
 /**
- * A single line component within a row of the schemaTable.
- * If the content text overflows, returns a line component with
- * the text ellipsed and tooltip is used to display full text instead.
+ * A single line component within a row of the schemaTable
+ * which uses a tooltip to display the full text.
+ * If the content text overflows, the text is ellipsed.
+ * (the tooltip is always implemented regardless of whether text
+ * overflows or not in order to avoid complexities with dealing
+ * with detectin changes when the window size changes)
  */
 function OverflowLine({ classes, content }) {
-  /**
-   * Track the textOverflow state depending on the component's
-   * width size relative to the text's length.
-   */
-  const [isTextOverflow, setIsTextOverflow] = useState(false);
-  /**
-   * Create a callback ref method to use to track the component's
-   * width measurements.
-   * (using a callback ref ensures that changes made to the ref
-   *  component can update the isTextOverflow state)
-   */
-  const measuredRef = useCallback(element => {
-    if (element !== null) {
-      if (element.scrollWidth > element.offsetWidth) {
-        setIsTextOverflow(true);
-      }
-    }
-  }, []);
-
-  if (isTextOverflow) {
-    return (
-      <Tooltip title={content}>
-        <div className={classes.line}>
-          <Typography
-            component="div"
-            variant="subtitle2"
-            ref={measuredRef}
-            noWrap>
-            {content}
-          </Typography>
-        </div>
-      </Tooltip>
-    );
-  }
 
   return (
-    <Typography
-      component="div"
-      variant="subtitle2"
-      className={classes.line}
-      ref={measuredRef}>
-      {content}
-    </Typography>
-  );
+    <Tooltip title={content}>
+      <div className={classes.line}>
+        <Typography
+          component="div"
+          variant="subtitle2"
+          noWrap>
+          {content}
+        </Typography>
+      </div>
+    </Tooltip>
+  )
 }
 
 OverflowLine.propTypes = {

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -40,6 +40,8 @@ const useStyles = makeStyles(theme => ({
    *  on how many keywords the given schema or sub-schema defines)
    */
   line: {
+    display: 'flex',	
+    alignItems: 'center',
     whiteSpace: 'nowrap',
     height: theme.spacing(3.5),
   },

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -40,8 +40,6 @@ const useStyles = makeStyles(theme => ({
    *  on how many keywords the given schema or sub-schema defines)
    */
   line: {
-    display: 'flex',
-    alignItems: 'center',
     whiteSpace: 'nowrap',
     height: theme.spacing(3.5),
   },

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles(theme => ({
    *  on how many keywords the given schema or sub-schema defines)
    */
   line: {
-    display: 'flex',	
+    display: 'flex',
     alignItems: 'center',
     whiteSpace: 'nowrap',
     height: theme.spacing(3.5),

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
   /** Rows for the left and right panels */
   row: {
     borderBottom: `${theme.spacing(0.25)}px solid ${theme.palette.divider}`,
-    minHeight: theme.spacing(3),
+    minHeight: theme.spacing(3.5),
     width: '100%',
   },
   lastRow: {
@@ -44,6 +44,9 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     whiteSpace: 'nowrap',
     height: theme.spacing(3.5),
+  },
+  descriptionLine: {
+    alignItems: 'flex-start',
   },
   /**
    * Highlighting the type for the schema or sub-schema displayed

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -1,39 +1,19 @@
 import React from 'react';
-import { string } from 'prop-types';
+import { string, node } from 'prop-types';
 import MuiTooltip from '@material-ui/core/Tooltip';
-import Chip from '@material-ui/core/Chip';
-import InfoIcon from '@material-ui/icons/Info';
 
-function Tooltip({ keyword }) {
-  /**
-   * Generate tooltip descriptions to provide further information
-   * regarding the given keywords.
-   * (only keywords defined as complex object types will need
-   *  tooltip descriptions)
-   */
-  const tooltipDescriptions = {
-    additionalItems: 'Additional items must match a sub-schema',
-    additionalProperties: 'Additional properties must match a sub-schema',
-    dependencies:
-      'The schema of the object may change based on the presence of certain special properties',
-    propertyNames: 'Names of properties must follow a specified convention',
-    patternProperties:
-      'Property names or values should match the specified pattern',
-  };
-  const createTooltipTitle = key =>
-    `${tooltipDescriptions[key]}. See the JSON-schema source for details.`;
-  const infoIcon = <InfoIcon fontSize="inherit" color="inherit" />;
-
+function Tooltip({ title, children }) {
   return (
-    <MuiTooltip title={createTooltipTitle(keyword)} arrow>
-      <Chip label={keyword} icon={infoIcon} size="small" variant="outlined" />
+    <MuiTooltip title={title} arrow>
+      {children}
     </MuiTooltip>
   );
 }
 
 Tooltip.propTypes = {
   /** Keyword to display with tooltip feature */
-  keyword: string.isRequired,
+  title: string.isRequired,
+  children: node,
 };
 
-export default React.memo(Tooltip);
+export default Tooltip;

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -4,7 +4,7 @@ import MuiTooltip from '@material-ui/core/Tooltip';
 
 function Tooltip({ title, children }) {
   return (
-    <MuiTooltip title={title} arrow>
+    <MuiTooltip title={title} arrow disableFocusListener enterTouchDelay={1}>
       {children}
     </MuiTooltip>
   );

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -50,6 +50,17 @@ export const SKIP_KEYWORDS = [
   '$ref',
   'definitions',
 ];
-
 /** Empty Function to use for default props */
 export const NOOP = () => {};
+/**
+ * 
+ */
+export const TOOLTIP_DESCRIPTIONS = {
+  additionalItems: 'Additional items must match a sub-schema.',
+  additionalProperties: 'Additional properties must match a sub-schema.',
+  dependencies:
+    'The schema of the object may change based on the presence of certain special properties.',
+  propertyNames: 'Names of properties must follow a specified convention.',
+  patternProperties:
+    'Property names or values should match the specified pattern.',
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -50,8 +50,10 @@ export const SKIP_KEYWORDS = [
   '$ref',
   'definitions',
 ];
-/** Empty Function to use for default props */
-export const NOOP = () => {};
+/**
+ * Max number of chips allowed to be displayed within a single line.
+ */
+export const MAX_NUMBER_OF_CHIPS = 3;
 /**
  *
  */

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -53,7 +53,7 @@ export const SKIP_KEYWORDS = [
 /** Empty Function to use for default props */
 export const NOOP = () => {};
 /**
- * 
+ *
  */
 export const TOOLTIP_DESCRIPTIONS = {
   additionalItems: 'Additional items must match a sub-schema.',

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -31,3 +31,8 @@ export const treeNode = shape({
   /** children nodes of the current node */
   children: array,
 });
+
+/**
+ * Empty Function to use for default props
+ */
+export const NOOP = () => {};

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -93,7 +93,7 @@ export function sanitizeSchema(schema) {
    * (for consistency with object type subschema's '_name' properties)
    */
   if ('name' in cloneSchema) {
-    cloneSchema._name = name;
+    cloneSchema._name = cloneSchema.name;
   }
 
   return cloneSchema;


### PR DESCRIPTION
Closes #51 
Fix multiple chip and long description display

**Applied Changes**
- [x] improve UI for when description is too long 
   - [x] create `OverflowLine` component
      - [x] truncate text and add triple dots/text-overflow ellipse `...` 
      - [x] display full text in tooltip when hovered upon
   - [x] fix descriptive keywords to use `OverflowLine` component
- [x] display title before description
- [x] render at most 3 chips per line 
- [x] sort the list of chips alphabetically

**Screenshot Results**
- tooltip when description is too long, title displays before description
<img src="https://user-images.githubusercontent.com/29671309/73641695-c23ba300-46b3-11ea-8ede-5d5425dadcab.png" width="400px" />

- chips alphabetically displayed, max 3 chips per line
<img src="https://user-images.githubusercontent.com/29671309/73641539-856fac00-46b3-11ea-8cb7-4ada4cec4b57.png" width="400px" />
