### PR TITLE
Fix display for default keyword in NormalRightRow

### DIFF
--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -26,6 +26,31 @@ function NormalRightRow({ schema, classes }) {
    * in order to inform users to refer to the source for more details.
    */
   function displaySpecKeyword(keyword) {
+    /**
+     * Typecast the definition in string format to display properly.
+     */
+    const keyValue = (function keyValueToString(key) {
+      if (Array.isArray(schema[keyword])) {
+        if (schema[keyword].length === 0) {
+          return '[ ]';
+        }
+
+        return schema[keyword];
+      }
+
+      if (
+        typeof schema[keyword] === 'object' &&
+        Object.keys(schema[keyword].length === 0)
+      ) {
+        return '{ }';
+      }
+
+      return schema[key];
+    })(keyword);
+
+    /**
+     * Display chip within tooltip for complex definitions.
+     */
     if (
       typeof schema[keyword] === 'object' &&
       !Array.isArray(schema[keyword])
@@ -36,7 +61,7 @@ function NormalRightRow({ schema, classes }) {
     return (
       <Chip
         key={keyword}
-        label={`${keyword}: ${schema[keyword]}`}
+        label={`${keyword}: ${keyValue}`}
         size="small"
         variant="outlined"
       />


### PR DESCRIPTION
Closes #50 
fix UI bug in display for `default` keyword in NormalRightRow

**Applied Changes**
- [x] display `[ ]` when keyword's value is defined as an empty array
- [x] display `{ }` when keyword's value is defined as an empty object

**Result**

<img src="https://user-images.githubusercontent.com/29671309/72065002-831e6a00-3320-11ea-96bd-1d1aa7addf88.png" width="500px" />
