### PR TITLE
Add custom keywords in schema

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -13,6 +13,11 @@ module.exports = {
         'no-use-before-define': ['error', { 
           functions: false,
         }],
+        /**
+         * Allow dangling underscores in identifiers.
+         * This is specifically enabled to use custom fields in the schemas.
+         */
+        'no-underscore-dangle': ['off'],
         'import/prefer-default-export': ['off'],
         /**
          * Allow both '.jsx' and '.js' file extensions to contain JSX

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -39,13 +39,7 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
    * If a name property is not defined within the schema,
    * set it to null in order to not display any name.
    */
-  const name = (function findName(schema) {
-    if (schema._name) return schema._name;
-
-    if (schema.name) return schema.name;
-
-    return null;
-  })(schema);
+  const name = schema._name || schema.name || null;
   /**
    * Define the type symbol for the schema or sub-schema's type
    * Types requiring nested structures use the according bracket symbol,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -46,6 +46,7 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
    * Complex types (allOf, anyOf, oneOf, no) use comment notation,
    * the rest simply use highlighted text to illustrate the data type.
    */
+  const schemaType = schema._type || schema.type;
   const typeSymbol = (function createTypeSymbol(type) {
     const bracketTypes = [...NESTED_TYPES, 'closeArray', 'closeObject'];
     const combinationTypes = [...COMBINATION_TYPES, 'and', 'or', 'nor'];
@@ -74,7 +75,7 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
     }
 
     return <code className={classes.code}>{type}</code>;
-  })(schema.type);
+  })(schemaType);
   /**
    * Define the required prefix (*) if the schema type
    * is a required property of an object.

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -39,7 +39,13 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
    * If a name property is not defined within the schema,
    * set it to null in order to not display any name.
    */
-  const name = 'name' in schema ? schema.name : null;
+  const name = (function findName(schema) {
+    if (schema._name) return schema._name;
+
+    if (schema.name) return schema.name;
+
+    return null;
+  })(schema);
   /**
    * Define the type symbol for the schema or sub-schema's type
    * Types requiring nested structures use the according bracket symbol,
@@ -77,17 +83,19 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
     return <code className={classes.code}>{type}</code>;
   })(schemaType);
   /**
-   * Define the required prefix (*) if the schema type
-   * is a required property of an object.
+   * Define the prefix used for the schema.
    */
-  const requiredPrefix =
-    'required' in schema && schema.required === true ? (
-      <span className={classes.prefix}>*</span>
-    ) : null;
-  const containsPrefix =
-    'contains' in schema && schema.contains === true ? (
-      <span className={classes.prefix}>⊃</span>
-    ) : null;
+  const prefix = (function createPrefix(schema) {
+    if (schema._required) {
+      return <span className={classes.prefix}>*</span>;
+    }
+
+    if (schema._contains) {
+      return <span className={classes.prefix}>⊃</span>;
+    }
+
+    return null;
+  })(schema);
   /**
    * If treeNode is $ref type, create $ref icon button for expanding
    * or shrinking the row depending on the the refType prop.
@@ -170,10 +178,9 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
         component="div"
         variant="subtitle2"
         className={classNames(classes.line, styles.indentation)}>
-        {containsPrefix}
+        {prefix}
         {name && `${name}: `}
         {typeSymbol}
-        {requiredPrefix}
         {refIcon}
       </Typography>
       {blankLinePaddings}

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -36,17 +36,15 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
   const styles = useStyles(indentSize);
   /**
    * Define the name to illustrate the schema or sub-schema.
-   * If a name property is not defined within the schema,
-   * set it to null in order to not display any name.
    */
-  const name = schema._name || schema.name || null;
+  const name = schema._name;
   /**
    * Define the type symbol for the schema or sub-schema's type
    * Types requiring nested structures use the according bracket symbol,
    * Complex types (allOf, anyOf, oneOf, no) use comment notation,
    * the rest simply use highlighted text to illustrate the data type.
    */
-  const schemaType = schema._type || schema.type;
+  const schemaType = schema._type;
   const typeSymbol = (function createTypeSymbol(type) {
     const bracketTypes = [...NESTED_TYPES, 'closeArray', 'closeObject'];
     const combinationTypes = [...COMBINATION_TYPES, 'and', 'or', 'nor'];

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -120,6 +120,8 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
    */
   function createLiteralRow(treeNode) {
     const { schema, path } = treeNode;
+    const schemaType = schema._type || schema.type;
+
     const literalSchema = {
       type: {
         array: 'closeArray',
@@ -128,7 +130,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
         anyOf: 'or',
         oneOf: 'or',
         not: 'nor',
-      }[schema.type],
+      }[schemaType],
     };
     const literalTreeNode = createSchemaTree(literalSchema, path);
 
@@ -152,7 +154,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
    */
   function renderNodeToRows(rootNode, refType = 'none') {
     /**
-     *
+     * If rootNode is a $ref type, render rows based on ref node.
      */
     if ('isExpanded' in rootNode) {
       renderRefNodeToRows(rootNode);
@@ -164,6 +166,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
      * Create a row based on the rootNode
      */
     const { schema, children } = rootNode;
+    const schemaType = schema._type || schema.type;
     const rootNodeRow = createSingleRow(rootNode, refType);
 
     pushRow(rootNodeRow);
@@ -178,7 +181,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
          * If root node's schema defines a combination type,
          * add separator rows in between the option rows
          */
-        if (COMBINATION_TYPES.includes(schema.type) && i > 0) {
+        if (COMBINATION_TYPES.includes(schemaType) && i > 0) {
           const separatorRow = createLiteralRow(rootNode);
 
           pushRow(separatorRow);
@@ -192,7 +195,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
      * If root node's schema defines a nested structure,
      * add a row at the end to close off the nested structure
      */
-    if (NESTED_TYPES.includes(schema.type)) {
+    if (NESTED_TYPES.includes(schemaType)) {
       const closeRow = createLiteralRow(rootNode);
 
       pushRow(closeRow);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -136,7 +136,8 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
         not: 'nor',
       }[schemaType],
     };
-    const literalTreeNode = createSchemaTree(literalSchema, path);
+    const literalPath = COMBINATION_TYPES.includes(schemaType) ? [...path, 0] : path;
+    const literalTreeNode = createSchemaTree(literalSchema, literalPath);
 
     return createSingleRow(literalTreeNode);
   }

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -88,7 +88,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
    * into the leftPanelRows and rightPanelRows arrays respectively.
    */
   function createSingleRow(treeNode, refType = 'none') {
-    /** 
+    /**
      * If the row to create is a refType (either 'default' or 'expanded'),
      * make sure to pass 'setSchemaTree' method to change the state of the
      * schemaTree. Else, pass null as prop instead.
@@ -151,7 +151,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
   }
 
   /**
-   * Create rows by traversing the tree structure, 
+   * Create rows by traversing the tree structure,
    * starting from the rootNode, in pre-order.
    * First, a single row based on the root node will be created.
    * Then, if the root node has children, this method may be called
@@ -209,7 +209,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
 
   /**
    * Depending on the refTreeNode's 'isExpanded' state,
-   * create either a default collapsed version of a refRow 
+   * create either a default collapsed version of a refRow
    * or an expanded version of possibly multiple rows.
    */
   function renderRefNodeToRows(refTreeNode) {

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -88,6 +88,11 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
    * into the leftPanelRows and rightPanelRows arrays respectively.
    */
   function createSingleRow(treeNode, refType = 'none') {
+    /** 
+     * If the row to create is a refType (either 'default' or 'expanded'),
+     * make sure to pass 'setSchemaTree' method to change the state of the
+     * schemaTree. Else, pass null as prop instead.
+     */
     const updateFunc = refType === 'none' ? null : setSchemaTree;
 
     return {
@@ -113,15 +118,14 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
   /**
    * Create a literal row for displaying descriptive rows.
    * This is only used to create rows for the following:
-   * - a closing row for nested types (arrays and objects) to display a
+   * * a closing row for nested types (arrays and objects) to display a
    *   close bracket symbol
-   * - a separator row for combination types (allOf, anyOf, oneOf, not)
+   * * a separator row for combination types (allOf, anyOf, oneOf, not)
    *   to visually separate options.
    */
   function createLiteralRow(treeNode) {
     const { schema, path } = treeNode;
     const schemaType = schema._type || schema.type;
-
     const literalSchema = {
       type: {
         array: 'closeArray',
@@ -147,8 +151,9 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
   }
 
   /**
-   * Traverse a tree or subtree in pre-order in order to create rows.
-   * First, a row based on the root node will be created.
+   * Create rows by traversing the tree structure, 
+   * starting from the rootNode, in pre-order.
+   * First, a single row based on the root node will be created.
    * Then, if the root node has children, this method may be called
    * recursively to create rows for the subtree structures.
    */
@@ -163,7 +168,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
     }
 
     /**
-     * Create a row based on the rootNode
+     * Create a single row based on the rootNode.
      */
     const { schema, children } = rootNode;
     const schemaType = schema._type || schema.type;
@@ -203,10 +208,9 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
   }
 
   /**
-   * Create a
    * Depending on the refTreeNode's 'isExpanded' state,
-   * create a shrunk version of a refRow.
-   *
+   * create either a default collapsed version of a refRow 
+   * or an expanded version of possibly multiple rows.
    */
   function renderRefNodeToRows(refTreeNode) {
     const { defaultNode, expandedNode, isExpanded } = refTreeNode;

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -125,7 +125,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
    */
   function createLiteralRow(treeNode) {
     const { schema, path } = treeNode;
-    const schemaType = schema._type || schema.type;
+    const schemaType = schema._type;
     const literalSchema = {
       type: {
         array: 'closeArray',
@@ -172,7 +172,7 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
      * Create a single row based on the rootNode.
      */
     const { schema, children } = rootNode;
-    const schemaType = schema._type || schema.type;
+    const schemaType = schema._type;
     const rootNodeRow = createSingleRow(rootNode, refType);
 
     pushRow(rootNodeRow);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -18,7 +18,11 @@ export const COMPLEX_TYPES = [...COMBINATION_TYPES, '$ref'];
  * in separation with specification keywords by a blank line.
  */
 export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
-/** */
+/**
+ * Custom keywords created within the schemas of the tree nodes.
+ * An underscore is prefixed for these keywords in order to
+ * distinguish them with the built-in keywords for schemas.
+ */
 export const CUSTOM_KEYWORDS = ['_type'];
 /**
  * Keywords used in schemas that will be ignored when 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,7 +23,7 @@ export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
  * An underscore is prefixed for these keywords in order to
  * distinguish them with the built-in keywords for schemas.
  */
-export const CUSTOM_KEYWORDS = ['_type'];
+export const CUSTOM_KEYWORDS = ['_type', '_contains'];
 /**
  * Keywords used in schemas that will be ignored when 
  * creating lines for the rows in the left and right panels.

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -18,7 +18,8 @@ export const COMPLEX_TYPES = [...COMBINATION_TYPES, '$ref'];
  * in separation with specification keywords by a blank line.
  */
 export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
-
+/** */
+export const CUSTOM_KEYWORDS = ['_type'];
 /**
  * Keywords used in schemas that will be ignored when 
  * creating lines for the rows in the left and right panels.
@@ -27,6 +28,7 @@ export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
    (ex. symbols in the left panel)
  */
 export const SKIP_KEYWORDS = [
+  ...CUSTOM_KEYWORDS,
   '$id',
   '$schema',
   'type',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,7 +23,7 @@ export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
  * An underscore is prefixed for these keywords in order to
  * distinguish them with the built-in keywords for schemas.
  */
-export const CUSTOM_KEYWORDS = ['_type', '_contains'];
+export const CUSTOM_KEYWORDS = ['_type', '_contains', '_required', '_name'];
 /**
  * Keywords used in schemas that will be ignored when 
  * creating lines for the rows in the left and right panels.

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -93,7 +93,7 @@ export function sanitizeSchema(schema) {
 /**
  * Create a child node based on the given subschema and append it to
  * the rootNode. (the child node may be a single node or a subtree)
- * @param {*} childIndex: the index of the child node (will be appended to its path)
+ * @param {*} childIndex: index of the child node (used for its path)
  */
 export function createChildNode(rootNode, subschema, childIndex) {
   const childNode = createSchemaTree(subschema, [...rootNode.path, childIndex]);

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -1,5 +1,5 @@
 import { clone } from 'ramda';
-import { COMBINATION_TYPES, COMPLEX_TYPES } from './constants';
+import { COMBINATION_TYPES, COMPLEX_TYPES, CUSTOM_KEYWORDS } from './constants';
 
 /**
  * Generate a tree that illustrates the recursive structure of a schema.
@@ -300,10 +300,26 @@ export function expandRefNode(schemaTree, refDefaultNode) {
     const refString = refDefaultNode.schema.$ref;
     const expandedRefSchema = fetchRefSchema(schemaTree, refString);
 
+    /**
+     * Create a subschema tree based on the fetched ref schema
+     * and store the result within the expandedNode field.
+     */
     refNode.expandedNode = createSchemaTree(
       expandedRefSchema,
       refDefaultNode.path
     );
+
+    /**
+     * If the ref node's default node has custom fields,
+     * also include those same fields within the expanded node.
+     */
+    const customKeywords = CUSTOM_KEYWORDS.filter(key => key !== '_type');
+
+    customKeywords.forEach(keyword => {
+      if (keyword in refDefaultNode.schema) {
+        refNode.expandedNode.schema[keyword] = refDefaultNode.schema[keyword];
+      }
+    });
   }
 
   return cloneTree;

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -50,7 +50,7 @@ export function createSchemaTree(schema, path = []) {
    * create children nodes according to its type and append them
    * sequentially as children to the root node.
    */
-  const schemaType = rootNode.schema._type || rootNode.schema.type;
+  const schemaType = rootNode.schema._type;
 
   if (COMBINATION_TYPES.includes(schemaType)) {
     createCombinationTree(rootNode);
@@ -75,16 +75,25 @@ export function sanitizeSchema(schema) {
   const cloneSchema = clone(schema);
 
   /**
-   * Make sure schemas have a type property for identification.
-   * (since complex type schemas do not specify '_type' properties)
-   * If the type is not specified purposely, leave type property out.
+   * Make sure schema has a '_type' property for identification.
+   * If the type is not specified purposely, leave property undefined.
    */
-  if (!('type' in cloneSchema)) {
+  if ('type' in cloneSchema) {
+    cloneSchema._type = cloneSchema.type;
+  } else {
     COMPLEX_TYPES.forEach(type => {
       if (type in cloneSchema) {
         cloneSchema._type = type;
       }
     });
+  }
+
+  /** 
+   * If name property exists, create a '_name' property with same value.
+   * (for consistency with object type subschema's '_name' properties)
+   */
+  if ('name' in cloneSchema) {
+    cloneSchema._name = name;
   }
 
   return cloneSchema;

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -167,7 +167,7 @@ export function createArrayTree(rootNode) {
     const subschema = schema.contains;
     const childIndex = rootNode.children.length;
 
-    subschema.contains = true;
+    subschema._contains = true;
     createChildNode(rootNode, subschema, childIndex);
   }
 }
@@ -200,10 +200,10 @@ export function createObjectTree(rootNode) {
     propertyList.forEach((property, childIndex) => {
       const subschema = schema.properties[property];
 
-      subschema.name = property;
+      subschema._name = property;
 
       if (requiredList.has(property)) {
-        subschema.required = true;
+        subschema._required = true;
       }
 
       createChildNode(rootNode, subschema, childIndex);

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -50,7 +50,7 @@ export function createSchemaTree(schema, path = []) {
    * create children nodes according to its type and append them
    * sequentially as children to the root node.
    */
-  const schemaType = rootNode.schema.type;
+  const schemaType = rootNode.schema._type || rootNode.schema.type;
 
   if (COMBINATION_TYPES.includes(schemaType)) {
     createCombinationTree(rootNode);
@@ -76,13 +76,13 @@ export function sanitizeSchema(schema) {
 
   /**
    * Make sure schemas have a type property for identification.
-   * (since complex type schemas do not specify 'type' properties)
+   * (since complex type schemas do not specify '_type' properties)
    * If the type is not specified purposely, leave type property out.
    */
   if (!('type' in cloneSchema)) {
     COMPLEX_TYPES.forEach(type => {
       if (type in cloneSchema) {
-        cloneSchema.type = type;
+        cloneSchema._type = type;
       }
     });
   }
@@ -93,6 +93,7 @@ export function sanitizeSchema(schema) {
 /**
  * Create a child node based on the given subschema and append it to
  * the rootNode. (the child node may be a single node or a subtree)
+ * @param {*} childIndex: the index of the child node (will be appended to its path)
  */
 export function createChildNode(rootNode, subschema, childIndex) {
   const childNode = createSchemaTree(subschema, [...rootNode.path, childIndex]);
@@ -107,7 +108,7 @@ export function createChildNode(rootNode, subschema, childIndex) {
  */
 export function createCombinationTree(rootNode) {
   const { schema } = rootNode;
-  const combType = schema.type;
+  const combType = schema._type;
 
   /**
    * If there are multiple options (defined in array form),


### PR DESCRIPTION
Closes #60 
prefix custom keywords with an underscore (to distinguish them from schema fields)

**Applied Changes**
- [x] fix eslint rule `no-underscore-dangle` to off
- [x] add `_type`, `_required`, `_contains`, `_name` custom fields
- [x] add custom fields to ref node's expanded node versions
   - [x]  if $ref is an object property, add `_name` to refNode.expandedNode's schema
   - [x] if $ref is a required property, add `_required` to refNode.expandedNodes' schema
   - [x] if $ref is a contains item, add `_contains` to refNode.expandedNode's schema
- [x] add a depth further in its path for the separator rows for combination types