### PR TITLE
Improve UI for prefix in NormalLeftRow

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandIcon from '@material-ui/icons/ArrowRightRounded';
 import ShrinkIcon from '@material-ui/icons/ArrowDropDownRounded';
+import Tooltip from '../Tooltip';
 import { treeNode, NOOP } from '../../utils/prop-types';
 import { expandRefNode, shrinkRefNode } from '../../utils/schemaTree';
 import {
@@ -13,6 +14,7 @@ import {
   DESCRIPTIVE_KEYWORDS,
   COMBINATION_TYPES,
   NESTED_TYPES,
+  TOOLTIP_DESCRIPTIONS,
 } from '../../utils/constants';
 
 /**
@@ -74,15 +76,23 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
     return <code className={classes.code}>{type}</code>;
   })(schemaType);
   /**
-   * Define the prefix used for the schema.
+   * Define the required/contains mark used for the schema.
    */
-  const prefix = (function createPrefix(schema) {
+  const requiredMark = (function createPrefix(schema) {
     if (schema._required) {
-      return <span className={classes.prefix}>*</span>;
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.required}>
+          <span className={classes.prefix}>*</span>
+        </Tooltip>
+      );
     }
 
     if (schema._contains) {
-      return <span className={classes.prefix}>⊃</span>;
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.contains}>
+          <span className={classes.prefix}>⊃</span>
+        </Tooltip>
+      );
     }
 
     return null;
@@ -172,9 +182,9 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
         component="div"
         variant="subtitle2"
         className={classNames(classes.line, styles.indentation)}>
-        {prefix}
         {name && `${name}: `}
         {typeSymbol}
+        {requiredMark}
         {refIcon}
       </Typography>
       {blankLinePaddings}

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -45,7 +45,7 @@ function NormalRightRow({ classes, treeNode }) {
       /**
        * Generate tooltip descriptions to match the keyword.
        */
-      const tooltipTitle = `${TOOLTIP_DESCRIPTIONS[keyword]} See the JSON-schema source for details.`;
+      const tooltipTitle = TOOLTIP_DESCRIPTIONS[keyword];
       const infoIcon = <InfoIcon fontSize="inherit" color="inherit" />;
 
       return (

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -58,13 +58,13 @@ export const MAX_NUMBER_OF_CHIPS = 3;
  *
  */
 export const TOOLTIP_DESCRIPTIONS = {
-  additionalItems: 'Additional items must match a sub-schema.',
-  additionalProperties: 'Additional properties must match a sub-schema.',
+  additionalItems: 'Additional items must match a sub-schema. See the JSON-schema source for details.',
+  additionalProperties: 'Additional properties must match a sub-schema. See the JSON-schema source for details.',
   dependencies:
-    'The schema of the object may change based on the presence of certain special properties.',
-  propertyNames: 'Names of properties must follow a specified convention.',
+    'The schema of the object may change based on the presence of certain special properties. See the JSON-schema source for details.',
+  propertyNames: 'Names of properties must follow a specified convention. See the JSON-schema source for details.',
   patternProperties:
-    'Property names or values should match the specified pattern.',
+    'Property names or values should match the specified pattern. See the JSON-schema source for details.',
   required: 'Required property',
-  contains: 'Only needs to validate against one or more items in the array.',
+  contains: 'Only needs to validate against one or more items in the array',
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -65,4 +65,6 @@ export const TOOLTIP_DESCRIPTIONS = {
   propertyNames: 'Names of properties must follow a specified convention.',
   patternProperties:
     'Property names or values should match the specified pattern.',
+  required: 'Required property',
+  contains: 'Only needs to validate against one or more items in the array.',
 };


### PR DESCRIPTION
Closes #67 
make `required` and `contains` symbol display consistent

**Applied Changes**
- [x] label symbols on right side: `*`, `⊃`
- [x] add tooltip for full description: required, contains field 