### PR TITLE
Add style to chip components

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ By default, the schema viewer inherits [material-ui's default theme](https://mat
 material-ui's [`ThemeProvider`](https://material-ui.com/styles/api/#themeprovider) component.
 You may also use material-ui's [`CSSBaseline`](https://material-ui.com/api/css-baseline/) to provide a more consistent style baseline as well.
 ```js
+const customTheme = createMuiTheme({
+    // change the theme object properties here
+});
 <CssBaseline />
 <ThemeProvider theme={customTheme}>
-    <SchemaTable />
+    <SchemaViewer />
 </ThemeProvider>
 ```

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -51,6 +51,7 @@ function NormalRightRow({ classes, treeNode }) {
       return (
         <Tooltip key={keyword} title={tooltipTitle}>
           <Chip
+            className={classes.chip}
             label={keyword}
             icon={infoIcon}
             size="small"
@@ -84,6 +85,7 @@ function NormalRightRow({ classes, treeNode }) {
 
     return (
       <Chip
+        className={classes.chip}
         key={keyword}
         label={`${keyword}: ${keyValue}`}
         size="small"
@@ -216,13 +218,17 @@ function NormalRightRow({ classes, treeNode }) {
 
 NormalRightRow.propTypes = {
   /**
-   * Style for rows and lines for schema viewer.
-   * Necessary to maintain consistency with left panel's
-   * rows and lines.
+   * Style for schema table.
    */
   classes: shape({
+    /**
+     * Rows and lines need to maintain consistent
+     * with left panel's rows and lines.
+     */ 
     row: string.isRequired,
     line: string.isRequired,
+    /** Style chips wrapping keyword displays */
+    chip: string.isRequired,
   }).isRequired,
   /**
    * Tree node object data structure.

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'flex-start',
   },
   /**
-   * Highlighting the type for the schema or sub-schema displayed
+   * Highlight the type for the schema or sub-schema displayed
    * in the left panel of the schema table component.
    */
   code: {
@@ -66,7 +66,14 @@ const useStyles = makeStyles(theme => ({
    */
   prefix: {
     color: theme.palette.error.main,
-    padding: `0 ${theme.spacing(0.5)}px}`,
+    padding: `0 ${theme.spacing(0.5)}px`,
+  },
+  /**
+   * Chips used for keyword notations.
+   */
+  chip: {
+    color: theme.palette.text.primary,
+    borderColor: theme.palette.text.primary
   },
 }));
 


### PR DESCRIPTION
Closes #66 
add style to color chip components

**Result Screenshots**
- Dark theme

![image](https://user-images.githubusercontent.com/29671309/73729177-e82a7b80-4777-11ea-83e0-5c50b03bc407.png)
- Yellow-Bluegrey Theme:

![image](https://user-images.githubusercontent.com/29671309/73729201-f5476a80-4777-11ea-8da9-a873885e1bf5.png)

