### PR TITLE
Add mode feature to viewer

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -26,27 +26,21 @@ function Header({ schema, sourceMode, toggleMode }) {
    */
   const classes = useStyles();
 
-  /**
-   * 
-   */
-  const title = schema.title || 'No title';
-  const description = schema.description || 'No description available';
-
   return (
     <div className={classes.container}>
       <Typography component="div" variant="h6" className={classes.title}>
-        {title}
+        {schema.title}
         {` `}
         <Button
           className={classes.button}
           color="inherit"
           size="small"
-          onClick={() => toggleMode()}>
+          onClick={toggleMode}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>
       </Typography>
       <Typography component="div" variant="subtitle2">
-        {description}
+        {schema.description}
       </Typography>
     </div>
   );

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -26,10 +26,16 @@ function Header({ schema, sourceMode, toggleMode }) {
    */
   const classes = useStyles();
 
+  /**
+   * 
+   */
+  const title = schema.title || 'No title';
+  const description = schema.description || 'No description available';
+
   return (
     <div className={classes.container}>
       <Typography component="div" variant="h6" className={classes.title}>
-        {schema.title}
+        {title}
         {` `}
         <Button
           className={classes.button}
@@ -40,7 +46,7 @@ function Header({ schema, sourceMode, toggleMode }) {
         </Button>
       </Typography>
       <Typography component="div" variant="subtitle2">
-        {schema.description}
+        {description}
       </Typography>
     </div>
   );

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -7,10 +7,10 @@ import { schema } from '../../utils/prop-types';
 
 const useStyles = makeStyles(theme => ({
   container: {
-    backgroundColor: theme.palette.grey[300],
+    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
     color: theme.palette.text.primary,
     padding: `${theme.spacing(1.5)}px ${theme.spacing(1)}px`,
-    marginBottom: `${theme.spacing(1)}px`,
+    marginBottom: theme.spacing(1),
   },
   title: {
     margin: 0,

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -34,7 +34,7 @@ function Header({ schema, sourceMode, toggleMode }) {
         className={classes.title}>
         {schema.title}
         {` `}
-        <Button className={classes.button} size="small" onClick={() => toggleMode()}>
+        <Button className={classes.button} color="inherit" size="small" onClick={() => toggleMode()}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>
       </Typography>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -28,20 +28,19 @@ function Header({ schema, sourceMode, toggleMode }) {
 
   return (
     <div className={classes.container}>
-      <Typography
-        component="div"
-        variant="h6"
-        className={classes.title}>
+      <Typography component="div" variant="h6" className={classes.title}>
         {schema.title}
         {` `}
-        <Button className={classes.button} color="inherit" size="small" onClick={() => toggleMode()}>
+        <Button
+          className={classes.button}
+          color="inherit"
+          size="small"
+          onClick={() => toggleMode()}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>
       </Typography>
-      <Typography
-        component="div"
-        variant="subtitle2">
-          {schema.description}
+      <Typography component="div" variant="subtitle2">
+        {schema.description}
       </Typography>
     </div>
   );

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { bool, func } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { schema } from '../../utils/prop-types';
 
@@ -12,9 +13,11 @@ const useStyles = makeStyles(theme => ({
     marginBottom: `${theme.spacing(1)}px`,
   },
   title: {
-    marginTop: 0,
+    margin: 0,
   },
-  button: {},
+  button: {
+    margin: 0,
+  },
 }));
 
 function Header({ schema, sourceMode, toggleMode }) {
@@ -25,14 +28,21 @@ function Header({ schema, sourceMode, toggleMode }) {
 
   return (
     <div className={classes.container}>
-      <h4 className={classes.title}>
+      <Typography
+        component="div"
+        variant="h6"
+        className={classes.title}>
         {schema.title}
         {` `}
-        <Button className={classes.button} onClick={() => toggleMode()}>
+        <Button className={classes.button} size="small" onClick={() => toggleMode()}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>
-      </h4>
-      {/* <Markdown>{schema.description}</Markdown> -> markdown-it package */}
+      </Typography>
+      <Typography
+        component="div"
+        variant="subtitle2">
+          {schema.description}
+      </Typography>
     </div>
   );
 }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import { schema } from '../../utils/prop-types';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    backgroundColor: theme.palette.grey[300],
+    color: theme.palette.text.primary,
+    padding: `${theme.spacing(1.5)}px ${theme.spacing(1)}px`,
+    marginBottom: `${theme.spacing(1)}px`,
+  },
+  title: {
+    marginTop: 0,
+  },
+  button: {},
+}));
+
+function Header({ schema, sourceMode, toggleMode }) {
+  /**
+   * Generate classes to define overall style for the schema table.
+   */
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <h4 className={classes.title}>
+        {schema.title}
+        {` `}
+        <Button className={classes.button} onClick={() => toggleMode()}>
+          {sourceMode ? 'hide' : 'show'} source
+        </Button>
+      </h4>
+      {/* <Markdown>{schema.description}</Markdown> -> markdown-it package */}
+    </div>
+  );
+}
+
+Header.propTypes = {
+  schema: schema.isRequired,
+  sourceMode: bool.isRequired,
+  toggleMode: func.isRequired,
+};
+
+export default React.memo(Header);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -1,8 +1,9 @@
 import React, { Fragment } from 'react';
-import { shape, string, array, number, func } from 'prop-types';
+import { func } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import NormalLeftRow from '../NormalLeftRow';
 import NormalRightRow from '../NormalRightRow';
+import { treeNode } from '../../utils/prop-types';
 import { createSchemaTree } from '../../utils/schemaTree';
 import { COMBINATION_TYPES, NESTED_TYPES } from '../../utils/constants';
 
@@ -266,14 +267,7 @@ SchemaTable.propTypes = {
    * Schema tree structure defining the overall structure
    * for the schema table component.
    */
-  schemaTree: shape({
-    schema: shape({
-      /** Type of schema */
-      type: string,
-    }),
-    children: array,
-    depth: number,
-  }).isRequired,
+  schemaTree: treeNode.isRequired,
   /**
    * Function to update schemaTree structure.
    * Used specifically for expanding or shrinking a $ref.

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -137,7 +137,9 @@ function SchemaTable({ schemaTree, setSchemaTree }) {
         not: 'nor',
       }[schemaType],
     };
-    const literalPath = COMBINATION_TYPES.includes(schemaType) ? [...path, 0] : path;
+    const literalPath = COMBINATION_TYPES.includes(schemaType)
+      ? [...path, 0]
+      : path;
     const literalTreeNode = createSchemaTree(literalSchema, literalPath);
 
     return createSingleRow(literalTreeNode);

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles(theme => ({
   },
   /** The left panel of the Schema Table */
   leftPanel: {
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
     borderRight: `${theme.spacing(1)}px solid ${theme.palette.divider}`,
     overflowX: 'auto',
   },
   /** The right panel of the Schema Table */
   rightPanel: {
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
     overflowX: 'auto',
   },
   /** Rows for the left and right panels */

--- a/src/components/SchemaViewer/index.jsx
+++ b/src/components/SchemaViewer/index.jsx
@@ -43,7 +43,7 @@ function SchemaViewer({ schema }) {
 
 SchemaViewer.propTypes = {
   /** Schema input given to render */
-  schema: schema,
+  schema,
 };
 
 SchemaViewer.defaultProps = {

--- a/src/components/SchemaViewer/index.jsx
+++ b/src/components/SchemaViewer/index.jsx
@@ -49,8 +49,6 @@ SchemaViewer.propTypes = {
 SchemaViewer.defaultProps = {
   /** Null type schema is set as default prop */
   schema: {
-    title: 'Empty title',
-    description: 'No description available',
     type: 'null',
   },
 };

--- a/src/components/SchemaViewer/index.jsx
+++ b/src/components/SchemaViewer/index.jsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
-import { shape, string } from 'prop-types';
+import React, { useState, Fragment } from 'react';
+import Header from '../Header';
 import SchemaTable from '../SchemaTable';
+import SourceView from '../SourceView';
+import { schema } from '../../utils/prop-types';
 import { createSchemaTree } from '../../utils/schemaTree';
 
 function SchemaViewer({ schema }) {
@@ -8,27 +10,47 @@ function SchemaViewer({ schema }) {
    * Create a tree structure based on the given schema.
    * This acts as an intermediary data structure to define the overall
    * structure the schemaTable component will create based upon.
-   * It is managed as a state in order to handle the dynamic structure
-   * of $ref schemas so that when a cetain $ref is expanded or shrunk,
    * the entire tree structure will be updated to re-create and re-render
-   * the schema table.
+   * the schema table when a $ref is expanded or shrunk.
    */
   const [schemaTree, setSchemaTree] = useState(createSchemaTree(schema));
+  /**
+   * Track the mode of the schema viewer.
+   * By default, the mode is set to a table mode to display a schemaTable.
+   * If the mode is set to a source mode, displays the schema source instead.
+   */
+  const [sourceMode, setSourceMode] = useState(false);
 
-  return <SchemaTable schemaTree={schemaTree} setSchemaTree={setSchemaTree} />;
+  function handleViewToggle() {
+    setSourceMode(prev => !prev);
+  }
+
+  return (
+    <Fragment>
+      <Header
+        schema={schema}
+        sourceMode={sourceMode}
+        toggleMode={handleViewToggle}
+      />
+      {sourceMode ? (
+        <SourceView schema={schema} />
+      ) : (
+        <SchemaTable schemaTree={schemaTree} setSchemaTree={setSchemaTree} />
+      )}
+    </Fragment>
+  );
 }
 
 SchemaViewer.propTypes = {
   /** Schema input given to render */
-  schema: shape({
-    /** Type of schema */
-    type: string,
-  }),
+  schema: schema,
 };
 
 SchemaViewer.defaultProps = {
   /** Null type schema is set as default prop */
   schema: {
+    title: 'Empty title',
+    description: 'No description available',
     type: 'null',
   },
 };

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -123,17 +123,9 @@ export const refTypes = () => (
 export const demo = () => (
   <Fragment>
     <h2>Demo of Taskcluster Schemas</h2>
-    <h3>Hook Status</h3>
-    <p>example of use of object, combination, default types</p>
     <SchemaViewer schema={demoSchemas.hookStatus} />
-    <h3>List Clients Response</h3>
-    <p>example of use of object, array, default types</p>
     <SchemaViewer schema={demoSchemas.listClients} />
-    <h3>Metadata Metaschema</h3>
-    <p>example of use of combination, array, $ref types</p>
     <SchemaViewer schema={demoSchemas.metaData} />
-    <h3>Worker List</h3>
-    <p>example of use of object, $ref types</p>
     <SchemaViewer schema={demoSchemas.workerList} />
   </Fragment>
 );
@@ -151,9 +143,10 @@ export const customThemes = () => {
       },
       background: {
         default: '#eceff1',
-      }
+      },
     },
   });
+
   return (
     <Fragment>
       <h3>Dark Theme</h3>
@@ -166,4 +159,4 @@ export const customThemes = () => {
       </ThemeProvider>
     </Fragment>
   );
-}
+};

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -141,9 +141,6 @@ export const customThemes = () => {
       text: {
         primary: '#ffc107',
       },
-      background: {
-        default: '#eceff1',
-      },
     },
   });
 

--- a/src/components/SourceView/index.jsx
+++ b/src/components/SourceView/index.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { schema } from '../../utils/prop-types';
+
+const useStyles = makeStyles(theme => ({
+  view: {
+    backgroundColor: theme.palette.background.default,
+    color: theme.palette.text.primary,
+    overflowX: 'auto',
+  },
+}));
+
+function SourceView({ schema }) {
+  /**
+   * Generate classes to define overall style for the schema table.
+   */
+  const classes = useStyles();
+  const source = JSON.stringify(schema, undefined, 2);
+
+  return (
+    <pre className={classes.view}>
+      <code>{source}</code>
+    </pre>
+  );
+}
+
+SourceView.propTypes = {
+  schema: schema.isRequired,
+};
+
+export default React.memo(SourceView);

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -1,4 +1,4 @@
-import { shape, string, arrayOf, number, array } from 'prop-types';
+import { shape, string, arrayOf, number, array, oneOf } from 'prop-types';
 
 export const schema = shape({
   /** Descriptive information about schema */
@@ -6,7 +6,15 @@ export const schema = shape({
   description: string,
   name: string,
   /** Type of schema */
-  type: string,
+  type: oneOf([
+    'string',
+    'number',
+    'integer',
+    'null',
+    'boolean',
+    'object',
+    'array',
+  ]),
 });
 
 export const treeNode = shape({

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -1,16 +1,20 @@
 import { shape, string, arrayOf, number, array } from 'prop-types';
 
+export const schema = shape({
+  /** Descriptive information about schema */
+  title: string,
+  description: string,
+  name: string,
+  /** Type of schema */
+  type: string,
+});
+
 export const treeNode = shape({
   /**
    * Schema given to render upon. May also be a sub-schema in case
    * for array items, object properties or more complex schemas.
    */
-  schema: shape({
-    /** Type of schema or sub-schema */
-    type: string,
-    /** Name of schema or sub-schema */
-    name: string,
-  }).isRequired,
+  schema: schema.isRequired,
   /**
    * Path from root to current tree node.
    * Necessary in order to calculate the indent size.

--- a/src/utils/schemaTree.js
+++ b/src/utils/schemaTree.js
@@ -88,7 +88,7 @@ export function sanitizeSchema(schema) {
     });
   }
 
-  /** 
+  /**
    * If name property exists, create a '_name' property with same value.
    * (for consistency with object type subschema's '_name' properties)
    */


### PR DESCRIPTION
Closes #37 

**Applied Changes**
- [x] Add dual view mode to schemaViewer component
- [x] Create `Header` component for title and mode button
- [x] Create `SourceView` component to view schema source
- [x] Fix demo examples for Storybook

**Screenshot Results**

| table mode | source mode |
|:---|:---|
| <img src="https://user-images.githubusercontent.com/29671309/74140349-405df380-4c38-11ea-8064-2dcefb4d56ef.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/29671309/74140383-4d7ae280-4c38-11ea-869e-1966b1580da7.png" width="250px" /> |
