### PR TITLE
Fix color implementation of schemaTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ material-ui's [`ThemeProvider`](https://material-ui.com/styles/api/#themeprovide
 You may also use material-ui's [`CSSBaseline`](https://material-ui.com/api/css-baseline/) to provide a more consistent style baseline as well.
 ```js
 const customTheme = createMuiTheme({
-    // change the theme object properties here
+    palette: {
+      background: {
+        paper: '#000', // change the background color
+      },
+      text: {
+        primary: '#ffc107', // change the text color
+        secondary: '#ffc53d', // change chip's border color
+        hint: '#ddd', // change comment color
+      },
+      divider: '#4f4f4f', // change table's border color
+    },
 });
 <CssBaseline />
 <ThemeProvider theme={customTheme}>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -7,7 +7,7 @@ import { schema } from '../../utils/prop-types';
 
 const useStyles = makeStyles(theme => ({
   container: {
-    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
+    backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
     padding: `${theme.spacing(1.5)}px ${theme.spacing(1)}px`,
     marginBottom: theme.spacing(1),

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -104,12 +104,12 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
   const refIcon = {
     none: null,
     default: (
-      <IconButton aria-label="expand-ref">
+      <IconButton aria-label="expand-ref" color="inherit">
         <ExpandIcon fontSize="large" />
       </IconButton>
     ),
     expanded: (
-      <IconButton aria-label="shrink-ref">
+      <IconButton aria-label="shrink-ref" color="inherit">
         <ShrinkIcon fontSize="large" />
       </IconButton>
     ),

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles(theme => ({
    */
   chip: {
     color: theme.palette.text.primary,
-    borderColor: theme.palette.text.primary
+    borderColor: theme.palette.text.secondary,
   },
 }));
 

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -53,7 +53,8 @@ const useStyles = makeStyles(theme => ({
    * in the left panel of the schema table component.
    */
   code: {
-    backgroundColor: theme.palette.grey[300],
+    backgroundColor: theme.palette.text.primary,
+    color: theme.palette.getContrastText(theme.palette.text.primary),
     padding: `0 ${theme.spacing(0.5)}px`,
   },
   /** Comments within the left panel (used for combination types) */

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles(theme => ({
   },
   /** The left panel of the Schema Table */
   leftPanel: {
-    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
+    backgroundColor: theme.palette.background.paper,
     borderRight: `${theme.spacing(1)}px solid ${theme.palette.divider}`,
     overflowX: 'auto',
   },
   /** The right panel of the Schema Table */
   rightPanel: {
-    backgroundColor: theme.palette.getContrastText(theme.palette.text.primary),
+    backgroundColor: theme.palette.background.paper,
     overflowX: 'auto',
   },
   /** Rows for the left and right panels */

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -138,9 +138,15 @@ export const customThemes = () => {
   });
   const colorfulTheme = createMuiTheme({
     palette: {
+      background: {
+        paper: '#000',
+      },
       text: {
         primary: '#ffc107',
+        secondary: '#ffc53d',
+        hint: '#ddd',
       },
+      divider: '#4f4f4f',
     },
   });
 
@@ -150,9 +156,13 @@ export const customThemes = () => {
       <ThemeProvider theme={darkTheme}>
         <SchemaViewer schema={objectSchemas.complexObjectExample} />
       </ThemeProvider>
-      <h3>Colorful Theme</h3>
+      <h3>Colorful Theme ex1</h3>
       <ThemeProvider theme={colorfulTheme}>
         <SchemaViewer schema={demoSchemas.workerList} />
+      </ThemeProvider>
+      <h3>Colorful Theme ex2</h3>
+      <ThemeProvider theme={colorfulTheme}>
+        <SchemaViewer schema={combinationSchemas.anyOf} />
       </ThemeProvider>
     </Fragment>
   );

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -152,7 +152,7 @@ export const customThemes = () => {
       </ThemeProvider>
       <h3>Colorful Theme</h3>
       <ThemeProvider theme={colorfulTheme}>
-        <SchemaViewer schema={objectSchemas.complexObjectExample} />
+        <SchemaViewer schema={demoSchemas.workerList} />
       </ThemeProvider>
     </Fragment>
   );

--- a/src/components/SourceView/index.jsx
+++ b/src/components/SourceView/index.jsx
@@ -4,7 +4,7 @@ import { schema } from '../../utils/prop-types';
 
 const useStyles = makeStyles(theme => ({
   view: {
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
     overflowX: 'auto',
   },


### PR DESCRIPTION
Closes #74 

**Applied Changes**
- [x] fix color of code class style (used for 'type' keyword)
- [x] fix color of comment class style (used for combination types)
- [x] fix color of table grid borders
- [x] fix color of expand/shrink buttons

**Screenshot Results**

| type block | expand/shrink button | 
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/29671309/74415625-12bab980-4e87-11ea-8fda-ac8eea5e9a60.png) | ![image](https://user-images.githubusercontent.com/29671309/74415516-dc7d3a00-4e86-11ea-9afb-f8d0e620bc75.png) | 
| __comments__ | __grid borders__ |
| ![image](https://user-images.githubusercontent.com/29671309/74419097-be1a3d00-4e8c-11ea-9c25-4efd471de3d1.png) | ![image](https://user-images.githubusercontent.com/29671309/74419302-089bb980-4e8d-11ea-9c20-e159ccfe5314.png) |
