### PR TITLE
Fix missing type keyword in schema cases

### DIFF
--- a/schemas/basicDataTypes/miscellaneous/multiple-type.json
+++ b/schemas/basicDataTypes/miscellaneous/multiple-type.json
@@ -1,5 +1,5 @@
 { 
-  "$id": "/schemas/basicDataTypes/miscellaneous/multiple-type.json",
+  "$id": "/schemas/basicDataTypes/miscellaneous/multiple-type.json#",
   "type": ["number", "string"],
   "minimum": 0,
   "maxLength": 10

--- a/schemas/basicDataTypes/miscellaneous/no-type.json
+++ b/schemas/basicDataTypes/miscellaneous/no-type.json
@@ -1,0 +1,11 @@
+{
+    "$id": "/schemas/basicDataTypes/miscellaneous/no-type.json#",
+    "properties": {
+        "someProp": {
+            "type": "number"
+        },
+        "someOtherProp": {
+            "type": "string"
+        }
+    }
+}

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandIcon from '@material-ui/icons/ArrowRightRounded';
 import ShrinkIcon from '@material-ui/icons/ArrowDropDownRounded';
+import WarningIcon from '@material-ui/icons/ReportProblemOutlined';
 import Tooltip from '../Tooltip';
 import { treeNode, NOOP } from '../../utils/prop-types';
 import { expandRefNode, shrinkRefNode } from '../../utils/schemaTree';
@@ -57,6 +58,12 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
       ...COMBINATION_TYPES,
       ...COMBINATION_TYPES.map(type => LITERAL_TYPES[type]),
     ];
+
+    if (!type) {
+      return (<Tooltip title={TOOLTIP_DESCRIPTIONS['noType']}>
+        <WarningIcon color="inherit"/>
+      </Tooltip>);
+    }
 
     /**
      * Types with nested structures use the a bracket symbol,

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -59,10 +59,15 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
       ...COMBINATION_TYPES.map(type => LITERAL_TYPES[type]),
     ];
 
+    /**
+     * If type is not specified, create a tooltip with an icon.
+     */
     if (!type) {
-      return (<Tooltip title={TOOLTIP_DESCRIPTIONS['noType']}>
-        <WarningIcon color="inherit"/>
-      </Tooltip>);
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.noType}>
+          <WarningIcon color="inherit" />
+        </Tooltip>
+      );
     }
 
     /**

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -52,6 +52,7 @@ refSchemas.circularReference = require('../../../schemas/refTypes/circularRefere
 const miscellaneousSchemas = {};
 
 miscellaneousSchemas.multipleTypes = require('../../../schemas/basicDataTypes/miscellaneous/multiple-type.json');
+miscellaneousSchemas.noType = require('../../../schemas/basicDataTypes/miscellaneous/no-type.json');
 
 const demoSchemas = {};
 
@@ -128,6 +129,8 @@ export const miscellaneous = () => (
   <Fragment>
     <h2>Multiple Types</h2>
     <SchemaViewer schema={miscellaneousSchemas.multipleTypes} />
+    <h2>No Type</h2>
+    <SchemaViewer schema={miscellaneousSchemas.noTypes} />
   </Fragment>
 );
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -119,5 +119,6 @@ export const TOOLTIP_DESCRIPTIONS = {
     'Property names or values should match the specified pattern. See the JSON-schema source for details.',
   required: 'Required property',
   contains: 'Only needs to validate against one or more items in the array',
-  noType: 'Type of schema is not specified. See the JSON-schema source for details.',
+  noType:
+    'Type of schema is not specified. See the JSON-schema source for details.',
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -119,4 +119,5 @@ export const TOOLTIP_DESCRIPTIONS = {
     'Property names or values should match the specified pattern. See the JSON-schema source for details.',
   required: 'Required property',
   contains: 'Only needs to validate against one or more items in the array',
+  noType: 'Type of schema is not specified. See the JSON-schema source for details.',
 };


### PR DESCRIPTION
Closes #64 

**Applied Changes**
- if a type is not specified, display ⚠️ icon in the left row with tooltip to instruct user to refer to the source instead

**Screenshot Results**

![image](https://user-images.githubusercontent.com/29671309/74655032-fc866380-51ce-11ea-840e-203dc6338020.png)

