### PR TITLE
Fix object key error

### DIFF
--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -81,7 +81,9 @@ function NormalLeftRow({ classes, treeNode, refType, setSchemaTree }) {
      * Combination types (allOf, anyOf, oneOf, no) use comment-like notation.
      */
     if (combinationTypes.includes(type)) {
-      return <span className={classes.comment}>{COMBINATION_SYMBOLS[type]}</span>;
+      return (
+        <span className={classes.comment}>{COMBINATION_SYMBOLS[type]}</span>
+      );
     }
 
     /**

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -141,6 +141,7 @@ function NormalRightRow({ classes, treeNode }) {
   function createTitleLine(keyword) {
     return (
       <Typography
+        key={keyword}
         className={classes.line}
         component="div"
         variant="subtitle2"


### PR DESCRIPTION
Closes #80 
fix key error in `createTitleLine()` method in NormalRightRow