### PR TITLE
Refactor chip to custom component

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -10,7 +10,7 @@ module.exports = {
          * Ignores reference to functions used before the function declaration. 
          * Since function declarations are hoisted, this is considered safe.
          */
-        'no-use-before-define': ['error', { 
+        'no-use-before-define': ['error', {
           functions: false,
         }],
         /**
@@ -23,8 +23,16 @@ module.exports = {
          * Allow both '.jsx' and '.js' file extensions to contain JSX
          * ('.js' files are necessary for stories)
          */
-        'react/jsx-filename-extension': ['error', { 
-          'extensions': ['.js', '.jsx'] 
+        'react/jsx-filename-extension': ['error', {
+          'extensions': ['.js', '.jsx']
+        }],
+        /**
+         * Allow exception to props spreading warning for divs.
+         * (so that the Tooltip component can apply to the div
+         *  wrapping children nodes, including custom components)
+         */
+        'react/jsx-props-no-spreading': ['error', {
+          'exceptions': ['div'],
         }],
         /**
          * 

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -35,7 +35,7 @@ module.exports = {
           'exceptions': ['div'],
         }],
         /**
-         * 
+         * Allow 'dangerouslySetInnerHTML' for Markdown component.
          */
         'react/no-danger': ['off'],
       },

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ Feel free to open an issue, submit a pull request, or contribute however you wou
 - Bump the version of the package with `npm version {version-name}` (patch, minor, major, etc.).
 - Generate the compiled component for publishing to npm with `yarn build`.
 - Publish the package with `npm publish --tag {tag-name}`
+- Deploy Storybook to gh-pages with `yarn deploy`

--- a/src/components/Chip/index.jsx
+++ b/src/components/Chip/index.jsx
@@ -1,8 +1,24 @@
 import React from 'react';
-import { shape, string, node, element } from 'prop-types';
+import { node, element } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
 import MuiChip from '@material-ui/core/Chip';
 
-function Chip({ classes, label, icon }) {
+const useStyles = makeStyles(theme => ({
+  /**
+   * Chips used for keyword notations.
+   */
+  chip: {
+    color: theme.palette.text.primary,
+    borderColor: theme.palette.text.secondary,
+  },
+}));
+
+function Chip({ label, icon }) {
+  /**
+   * Generate classes to use styles for chips.
+   */
+  const classes = useStyles();
+
   return (
     <MuiChip
       className={classes.chip}
@@ -15,13 +31,9 @@ function Chip({ classes, label, icon }) {
 }
 
 Chip.propTypes = {
-  /**
-   * Style for chips used in schema table.
-   */
-  classes: shape({
-    chip: string.isRequired,
-  }).isRequired,
+  /** Label for chip to display */
   label: node.isRequired,
+  /** Icon for chip to display */
   icon: element,
 };
 

--- a/src/components/Chip/index.jsx
+++ b/src/components/Chip/index.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shape, string, node, element } from 'prop-types';
+import MuiChip from '@material-ui/core/Chip';
+
+function Chip({ classes, label, icon }) {
+  return (
+    <MuiChip
+      className={classes.chip}
+      label={label}
+      icon={icon}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+Chip.propTypes = {
+  /**
+   * Style for chips used in schema table.
+   */
+  classes: shape({
+    chip: string.isRequired,
+  }).isRequired,
+  label: node.isRequired,
+  icon: element,
+};
+
+Chip.defaultProps = {
+  icon: null,
+}
+
+export default React.memo(Chip);

--- a/src/components/Chip/index.jsx
+++ b/src/components/Chip/index.jsx
@@ -27,6 +27,6 @@ Chip.propTypes = {
 
 Chip.defaultProps = {
   icon: null,
-}
+};
 
 export default React.memo(Chip);

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -52,7 +52,7 @@ function NormalRightRow({ classes, treeNode }) {
 
       return (
         <Tooltip key={keyword} title={tooltipTitle}>
-          <Chip classes={classes} label={keyword} icon={infoIcon} />
+          <Chip label={keyword} icon={infoIcon} />
         </Tooltip>
       );
     }
@@ -79,9 +79,7 @@ function NormalRightRow({ classes, treeNode }) {
       return schema[key];
     })(keyword);
 
-    return (
-      <Chip key={keyword} classes={classes} label={`${keyword}: ${keyValue}`} />
-    );
+    return <Chip key={keyword} label={`${keyword}: ${keyValue}`} />;
   }
 
   /**
@@ -209,17 +207,12 @@ function NormalRightRow({ classes, treeNode }) {
 NormalRightRow.propTypes = {
   /**
    * Style for schema table.
+   * Rows and lines need to maintain consistent
+   * with left panel's rows and lines.
    */
   classes: shape({
-    /**
-     * Rows and lines need to maintain consistent
-     * with left panel's rows and lines.
-     */
-
     row: string.isRequired,
     line: string.isRequired,
-    /** Style chips wrapping keyword displays */
-    chip: string.isRequired,
   }).isRequired,
   /**
    * Tree node object data structure.

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -52,11 +52,7 @@ function NormalRightRow({ classes, treeNode }) {
 
       return (
         <Tooltip key={keyword} title={tooltipTitle}>
-          <Chip
-            classes={classes}
-            label={keyword}
-            icon={infoIcon}
-          />
+          <Chip classes={classes} label={keyword} icon={infoIcon} />
         </Tooltip>
       );
     }
@@ -84,11 +80,7 @@ function NormalRightRow({ classes, treeNode }) {
     })(keyword);
 
     return (
-      <Chip
-        key={keyword}
-        classes={classes}
-        label={`${keyword}: ${keyValue}`}
-      />
+      <Chip key={keyword} classes={classes} label={`${keyword}: ${keyValue}`} />
     );
   }
 

--- a/src/components/NormalRightRow/index.jsx
+++ b/src/components/NormalRightRow/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import { isEmpty } from 'ramda';
-import Chip from '@material-ui/core/Chip';
 import InfoIcon from 'mdi-react/InformationOutlineIcon';
 import Markdown from '../Markdown';
+import Chip from '../Chip';
 import Tooltip from '../Tooltip';
 import OverflowLine from '../OverflowLine';
 import { basicTreeNode } from '../../utils/prop-types';
@@ -53,11 +53,9 @@ function NormalRightRow({ classes, treeNode }) {
       return (
         <Tooltip key={keyword} title={tooltipTitle}>
           <Chip
-            className={classes.chip}
+            classes={classes}
             label={keyword}
             icon={infoIcon}
-            size="small"
-            variant="outlined"
           />
         </Tooltip>
       );
@@ -87,11 +85,9 @@ function NormalRightRow({ classes, treeNode }) {
 
     return (
       <Chip
-        className={classes.chip}
         key={keyword}
+        classes={classes}
         label={`${keyword}: ${keyValue}`}
-        size="small"
-        variant="outlined"
       />
     );
   }

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -79,13 +79,6 @@ const useStyles = makeStyles(theme => ({
     padding: `0 ${theme.spacing(0.5)}px`,
   },
   /**
-   * Chips used for keyword notations.
-   */
-  chip: {
-    color: theme.palette.text.primary,
-    borderColor: theme.palette.text.secondary,
-  },
-  /**
    * Button used to expand or shrink a $ref.
    */
   refButton: {

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -187,7 +187,7 @@ export const customThemes = () => {
     <Fragment>
       <h3>Taskcluster Dark Theme</h3>
       <ThemeProvider theme={TASKCLUSTER_THEME.darkTheme}>
-        <SchemaViewer schema={objectSchemas.complexObjectExample} />
+        <SchemaViewer schema={demoSchemas.hookStatus} />
       </ThemeProvider>
       <h3>Taskcluster Light Theme</h3>
       <ThemeProvider theme={TASKCLUSTER_THEME.lightTheme}>

--- a/src/components/SourceView/index.jsx
+++ b/src/components/SourceView/index.jsx
@@ -7,6 +7,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
     overflowX: 'auto',
+    padding: theme.spacing(1),
+    margin: 0,
   },
 }));
 

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -2,10 +2,21 @@ import React from 'react';
 import { node } from 'prop-types';
 import MuiTooltip from '@material-ui/core/Tooltip';
 
+/**
+ * Tooltip accessible by hovering mouse or touching mobile screen.
+ */
 function Tooltip({ title, children }) {
+  /**
+   * Forward the properties and ref of the tooltip to the children components
+   * so that MuiTooltip has control over the wrapped components' props.
+   */
+  const ChildrenWrapped = React.forwardRef(function MyComponent(props, ref) {
+    return <div {...props} ref={ref}>{children}</div>
+  });
+
   return (
     <MuiTooltip title={title} arrow disableFocusListener enterTouchDelay={1}>
-      {children}
+      <ChildrenWrapped />
     </MuiTooltip>
   );
 }

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -11,7 +11,11 @@ function Tooltip({ title, children }) {
    * so that MuiTooltip has control over the wrapped components' props.
    */
   const ChildrenWrapped = React.forwardRef(function MyComponent(props, ref) {
-    return <div {...props} ref={ref}>{children}</div>
+    return (
+      <div {...props} ref={ref}>
+        {children}
+      </div>
+    );
   });
 
   return (

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -6,21 +6,9 @@ import MuiTooltip from '@material-ui/core/Tooltip';
  * Tooltip accessible by hovering mouse or touching mobile screen.
  */
 function Tooltip({ title, children }) {
-  /**
-   * Forward the properties and ref of the tooltip to the children components
-   * so that MuiTooltip has control over the wrapped components' props.
-   */
-  const ChildrenWrapped = React.forwardRef(function MyComponent(props, ref) {
-    return (
-      <div {...props} ref={ref}>
-        {children}
-      </div>
-    );
-  });
-
   return (
     <MuiTooltip title={title} arrow disableFocusListener enterTouchDelay={1}>
-      <ChildrenWrapped />
+      <div>{children}</div>
     </MuiTooltip>
   );
 }


### PR DESCRIPTION
Closes #71 

**Applied Changes**
- [x] enable `Tooltip` to use custom components (forward ref and props)
- [x] create custom `Chip` component with consistent chip style
- [x] replace usage of material-ui's chips with custom `Chip` component
- [x] enable exception for linting rule `no-props-spreading` 


