### PR TITLE
Change Storybook custom theme example to Taskcluster theme

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -13,7 +13,11 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(1),
   },
   title: {
+    color: theme.palette.text.primary,
     margin: 0,
+  },
+  description: {
+    color: theme.palette.text.primary,
   },
   button: {
     margin: 0,
@@ -39,7 +43,7 @@ function Header({ schema, sourceMode, toggleMode }) {
           {sourceMode ? 'hide' : 'show'} source
         </Button>
       </Typography>
-      <Typography component="div" variant="subtitle2">
+      <Typography component="div" variant="subtitle2" className={classes.description}>
         {schema.description}
       </Typography>
     </div>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -10,7 +10,6 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
     padding: `${theme.spacing(1.5)}px ${theme.spacing(1)}px`,
-    marginBottom: theme.spacing(1),
   },
   title: {
     color: theme.palette.text.primary,

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -43,7 +43,10 @@ function Header({ schema, sourceMode, toggleMode }) {
           {sourceMode ? 'hide' : 'show'} source
         </Button>
       </Typography>
-      <Typography component="div" variant="subtitle2" className={classes.description}>
+      <Typography
+        component="div"
+        variant="subtitle2"
+        className={classes.description}>
         {schema.description}
       </Typography>
     </div>

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -14,8 +14,8 @@ import Tooltip from '../Tooltip';
 function OverflowLine({ classes, content }) {
   return (
     <Tooltip title={content}>
-      <div className={classes.line}>
-        <Typography component="div" variant="subtitle2" noWrap>
+      <div>
+        <Typography component="div" variant="subtitle2" noWrap className={classes.line}>
           {content}
         </Typography>
       </div>

--- a/src/components/OverflowLine/index.jsx
+++ b/src/components/OverflowLine/index.jsx
@@ -15,7 +15,11 @@ function OverflowLine({ classes, content }) {
   return (
     <Tooltip title={content}>
       <div>
-        <Typography component="div" variant="subtitle2" noWrap className={classes.line}>
+        <Typography
+          component="div"
+          variant="subtitle2"
+          noWrap
+          className={classes.line}>
           {content}
         </Typography>
       </div>

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles(theme => ({
    *  on how many keywords the given schema or sub-schema defines)
    */
   line: {
+    color: theme.palette.text.primary,
     display: 'flex',
     alignItems: 'center',
     whiteSpace: 'nowrap',

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -198,10 +198,6 @@ export const customThemes = () => {
       <ThemeProvider theme={TASKCLUSTER_THEME.lightTheme}>
         <SchemaViewer schema={demoSchemas.workerList} />
       </ThemeProvider>
-      <h3>Taskcluster Dark Theme</h3>
-      <ThemeProvider theme={TASKCLUSTER_THEME.darkTheme}>
-        <SchemaViewer schema={combinationSchemas.anyOf} />
-      </ThemeProvider>
     </Fragment>
   );
 };

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import SchemaViewer from './index';
+import { TASKCLUSTER_THEME } from '../../utils/theme';
 
 export default {
   title: 'Schema Viewer',
@@ -187,37 +188,18 @@ export const demo = () => (
 );
 
 export const customThemes = () => {
-  const darkTheme = createMuiTheme({
-    palette: {
-      type: 'dark',
-    },
-  });
-  const colorfulTheme = createMuiTheme({
-    palette: {
-      background: {
-        paper: '#000',
-      },
-      text: {
-        primary: '#ffc107',
-        secondary: '#ffc53d',
-        hint: '#ddd',
-      },
-      divider: '#4f4f4f',
-    },
-  });
-
   return (
     <Fragment>
-      <h3>Dark Theme</h3>
-      <ThemeProvider theme={darkTheme}>
+      <h3>Taskcluster Dark Theme</h3>
+      <ThemeProvider theme={TASKCLUSTER_THEME.darkTheme}>
         <SchemaViewer schema={objectSchemas.complexObjectExample} />
       </ThemeProvider>
-      <h3>Colorful Theme ex1</h3>
-      <ThemeProvider theme={colorfulTheme}>
+      <h3>Taskcluster Light Theme</h3>
+      <ThemeProvider theme={TASKCLUSTER_THEME.lightTheme}>
         <SchemaViewer schema={demoSchemas.workerList} />
       </ThemeProvider>
-      <h3>Colorful Theme ex2</h3>
-      <ThemeProvider theme={colorfulTheme}>
+      <h3>Taskcluster Dark Theme</h3>
+      <ThemeProvider theme={TASKCLUSTER_THEME.darkTheme}>
         <SchemaViewer schema={combinationSchemas.anyOf} />
       </ThemeProvider>
     </Fragment>

--- a/src/components/SchemaViewer/index.stories.js
+++ b/src/components/SchemaViewer/index.stories.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import SchemaViewer from './index';
 import { TASKCLUSTER_THEME } from '../../utils/theme';
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,3 @@
-import SchemaViewer from '../src/components/SchemaViewer';
+import SchemaViewer from './components/SchemaViewer';
 
 export default SchemaViewer;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,3 +1,0 @@
-import { createMuiTheme } from '@material-ui/core/styles';
-
-export default createMuiTheme();

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -6,6 +6,10 @@ import amber from '@material-ui/core/colors/amber';
 import blue from '@material-ui/core/colors/blue';
 import green from '@material-ui/core/colors/green';
 
+/**
+ * Theme values are all copied from the Taskcluster UI source code:
+ * https://github.com/taskcluster/taskcluster/blob/master/ui/src/theme.js
+ */
 export const THEME = {
   WHITE: '#fff',
   BLACK: '#000',

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -7,22 +7,22 @@ import blue from '@material-ui/core/colors/blue';
 import green from '@material-ui/core/colors/green';
 
 export const THEME = {
-    WHITE: '#fff',
-    BLACK: '#000',
-    TEN_PERCENT_WHITE: fade('#fff', 0.1),
-    TEN_PERCENT_BLACK: fade('#000', 0.1),
-    DARK_THEME_BACKGROUND: '#12202c',
-    PRIMARY_DARK: '#1b2a39',
-    PRIMARY_LIGHT: '#fafafa',
-    PRIMARY_TEXT_DARK: 'rgba(255, 255, 255, 0.9)',
-    PRIMARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.9)',
-    SECONDARY_TEXT_DARK: 'rgba(255, 255, 255, 0.7)',
-    SECONDARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.7)',
-    SECONDARY: '#4177a5',
-    DRAWER_WIDTH: 240,
-    DIVIDER: 'rgba(0, 0, 0, 0.12)',
-    TONAL_OFFSET: 0.2,
-  };
+  WHITE: '#fff',
+  BLACK: '#000',
+  TEN_PERCENT_WHITE: fade('#fff', 0.1),
+  TEN_PERCENT_BLACK: fade('#000', 0.1),
+  DARK_THEME_BACKGROUND: '#12202c',
+  PRIMARY_DARK: '#1b2a39',
+  PRIMARY_LIGHT: '#fafafa',
+  PRIMARY_TEXT_DARK: 'rgba(255, 255, 255, 0.9)',
+  PRIMARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.9)',
+  SECONDARY_TEXT_DARK: 'rgba(255, 255, 255, 0.7)',
+  SECONDARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.7)',
+  SECONDARY: '#4177a5',
+  DRAWER_WIDTH: 240,
+  DIVIDER: 'rgba(0, 0, 0, 0.12)',
+  TONAL_OFFSET: 0.2,
+};
 export const Roboto300 = { fontFamily: 'Roboto300, sans-serif' };
 export const Roboto400 = { fontFamily: 'Roboto400, sans-serif' };
 export const Roboto500 = { fontFamily: 'Roboto500, sans-serif' };
@@ -468,33 +468,4 @@ export const theme = createMuiTheme(createTheme(true));
 export const TASKCLUSTER_THEME = {
   lightTheme: createMuiTheme(createTheme(false)),
   darkTheme: theme,
-  styleguide: {
-    StyleGuide: {
-      root: {
-        overflowY: 'scroll',
-        minHeight: '100vh',
-        backgroundColor: THEME.DARK_THEME_BACKGROUND,
-        color: theme.palette.text.primary,
-      },
-    },
-    fontFamily: {
-      base: theme.typography.fontFamily,
-    },
-    fontSize: {
-      base: theme.typography.fontSize - 1,
-      text: theme.typography.fontSize,
-      small: theme.typography.fontSize - 2,
-    },
-    color: {
-      base: theme.palette.text.primary,
-      link: theme.palette.text.primary,
-      linkHover: theme.palette.text.primary,
-      border: THEME.DIVIDER,
-      baseBackground: THEME.DARK_THEME_BACKGROUND,
-      sidebarBackground: theme.palette.primary.main,
-      codeBackground: theme.palette.primary.main,
-    },
-    sidebarWidth: THEME.DRAWER_WIDTH,
-    maxWidth: '100vw',
-  },
 };

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,500 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+import { fade, lighten } from '@material-ui/core/styles/colorManipulator';
+import transitions from '@material-ui/core/styles/transitions';
+import red from '@material-ui/core/colors/red';
+import amber from '@material-ui/core/colors/amber';
+import blue from '@material-ui/core/colors/blue';
+import green from '@material-ui/core/colors/green';
+
+export const THEME = {
+    WHITE: '#fff',
+    BLACK: '#000',
+    TEN_PERCENT_WHITE: fade('#fff', 0.1),
+    TEN_PERCENT_BLACK: fade('#000', 0.1),
+    DARK_THEME_BACKGROUND: '#12202c',
+    PRIMARY_DARK: '#1b2a39',
+    PRIMARY_LIGHT: '#fafafa',
+    PRIMARY_TEXT_DARK: 'rgba(255, 255, 255, 0.9)',
+    PRIMARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.9)',
+    SECONDARY_TEXT_DARK: 'rgba(255, 255, 255, 0.7)',
+    SECONDARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.7)',
+    SECONDARY: '#4177a5',
+    DRAWER_WIDTH: 240,
+    DIVIDER: 'rgba(0, 0, 0, 0.12)',
+    TONAL_OFFSET: 0.2,
+  };
+export const Roboto300 = { fontFamily: 'Roboto300, sans-serif' };
+export const Roboto400 = { fontFamily: 'Roboto400, sans-serif' };
+export const Roboto500 = { fontFamily: 'Roboto500, sans-serif' };
+export const success = {
+  main: green[500],
+  dark: green[700],
+  contrastText: THEME.PRIMARY_TEXT_DARK,
+};
+export const warning = {
+  main: amber[500],
+  dark: amber[700],
+  light: amber[200],
+  contrastText: THEME.PRIMARY_TEXT_LIGHT,
+};
+export const error = {
+  main: red[500],
+  dark: red[700],
+  light: red[300],
+  contrastText: THEME.PRIMARY_TEXT_DARK,
+};
+export const createTheme = isDarkTheme => {
+  const primaryMain = isDarkTheme ? THEME.PRIMARY_DARK : THEME.PRIMARY_LIGHT;
+  const textPrimary = isDarkTheme
+    ? THEME.PRIMARY_TEXT_DARK
+    : THEME.PRIMARY_TEXT_LIGHT;
+  const textSecondary = isDarkTheme
+    ? THEME.SECONDARY_TEXT_DARK
+    : THEME.SECONDARY_TEXT_LIGHT;
+  const textHint = isDarkTheme
+    ? 'rgba(255, 255, 255, 0.5)'
+    : 'rgba(0, 0, 0, 0.5)';
+  const TYPOGRAPHY = {
+    H1: Roboto300,
+    H2: Roboto400,
+    H3: Roboto400,
+    H4: Roboto400,
+    H5: Roboto400,
+    H6: Roboto500,
+    SUBTITLE1: Roboto400,
+    SUBTITLE2: Roboto500,
+    BODY1: Roboto400,
+    BODY2: Roboto400,
+    CAPTION: Roboto400,
+    BUTTON: Roboto500,
+  };
+  const FONT_WEIGHTS = {
+    LIGHT: 300,
+    REGULAR: 400,
+    MEDIUM: 500,
+    DARK: 600,
+  };
+
+  return {
+    palette: {
+      type: isDarkTheme ? 'dark' : 'light',
+      background: {
+        default: isDarkTheme ? THEME.DARK_THEME_BACKGROUND : '#fff',
+        paper: primaryMain,
+      },
+      primary: {
+        main: primaryMain,
+      },
+      secondary: {
+        main: THEME.SECONDARY,
+      },
+      error: {
+        ...red,
+        ...error,
+      },
+      success: {
+        ...green,
+        ...success,
+      },
+      warning: {
+        ...amber,
+        ...warning,
+      },
+      info: {
+        ...blue,
+      },
+      text: {
+        primary: textPrimary,
+        secondary: textSecondary,
+        disabled: isDarkTheme
+          ? 'rgba(255, 255, 255, 0.5)'
+          : 'rgba(0, 0, 0, 0.5)',
+        hint: textHint,
+        icon: isDarkTheme ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)',
+        active: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.9)',
+        inactive: isDarkTheme
+          ? 'rgba(255, 255, 255, 0.4)'
+          : 'rgba(0, 0, 0, 0.4)',
+      },
+    },
+    typography: {
+      ...Roboto400,
+      h1: TYPOGRAPHY.H1,
+      h2: TYPOGRAPHY.H2,
+      h3: TYPOGRAPHY.H3,
+      h4: TYPOGRAPHY.H4,
+      h5: TYPOGRAPHY.H5,
+      h6: TYPOGRAPHY.H6,
+      subtitle1: TYPOGRAPHY.SUBTITLE1,
+      subtitle2: TYPOGRAPHY.SUBTITLE2,
+      body1: TYPOGRAPHY.BODY1,
+      body2: TYPOGRAPHY.BODY2,
+      caption: TYPOGRAPHY.CAPTION,
+      button: TYPOGRAPHY.BUTTON,
+      fontWeightLight: FONT_WEIGHTS.LIGHT,
+      fontWeightRegular: FONT_WEIGHTS.REGULAR,
+      fontWeightMedium: FONT_WEIGHTS.MEDIUM,
+      fontWeightDark: FONT_WEIGHTS.DARK,
+    },
+    spacing: 8,
+    drawerWidth: THEME.DRAWER_WIDTH,
+    docsDrawerWidth: THEME.DRAWER_WIDTH + 125,
+    mixins: {
+      link: {
+        color: textPrimary,
+        textDecoration: 'none',
+        borderBottom: `2px solid ${lighten(
+          THEME.SECONDARY,
+          THEME.TONAL_OFFSET
+        )}`,
+        '&:hover': {
+          borderBottom: `2px solid ${THEME.SECONDARY}`,
+        },
+      },
+      highlight: {
+        backgroundColor: isDarkTheme
+          ? THEME.TEN_PERCENT_WHITE
+          : THEME.TEN_PERCENT_BLACK,
+        fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
+        lineHeight: 1.4,
+        display: 'inline-block',
+        fontSize: '0.875rem',
+      },
+      listItemButton: {
+        '& svg': {
+          transition: transitions.create('fill'),
+          fill: lighten(
+            isDarkTheme ? THEME.PRIMARY_TEXT_LIGHT : THEME.PRIMARY_TEXT_LIGHT,
+            0.4
+          ),
+        },
+        '&:hover svg, &:focus svg': {
+          fill: textPrimary,
+        },
+      },
+      hover: {
+        '&:hover, &:focus': {
+          textDecoration: 'none',
+          backgroundColor: fade(textPrimary, 0.08),
+          // Reset on touch devices, it doesn't add specificity
+          '@media (hover: none)': {
+            backgroundColor: 'transparent',
+          },
+          '&:disabled': {
+            backgroundColor: 'transparent',
+          },
+          // Rely on background color instead
+          outline: 'none',
+        },
+      },
+      fab: {
+        position: 'fixed',
+        bottom: 16,
+        right: 24,
+        '& .mdi-icon': {
+          fill: 'white',
+        },
+      },
+      fabIcon: {
+        '& .mdi-icon': {
+          fill: 'white',
+        },
+      },
+      secondaryIcon: {
+        backgroundColor: THEME.SECONDARY,
+        '&:hover': {
+          backgroundColor: fade(THEME.SECONDARY, 0.9),
+        },
+        '& svg': {
+          backgroundColor: 'transparent',
+        },
+      },
+      successIcon: {
+        backgroundColor: success.main,
+        '&:hover': {
+          backgroundColor: success.dark,
+        },
+        '& svg': {
+          backgroundColor: 'transparent',
+        },
+      },
+      warningIcon: {
+        backgroundColor: warning.main,
+        '&:hover': {
+          backgroundColor: warning.dark,
+        },
+        '& svg': {
+          backgroundColor: 'transparent',
+        },
+      },
+      errorIcon: {
+        backgroundColor: error.main,
+        '&:hover': {
+          backgroundColor: error.dark,
+        },
+        '& svg': {
+          backgroundColor: 'transparent',
+        },
+      },
+      unorderedList: {
+        wordWrap: 'break-word',
+        listStyleType: 'square',
+        paddingLeft: 32,
+      },
+      // An action button is usually located bottom right
+      // of the screen. The class should be used on the Button component
+      // to ensure other components (e.g., code editors) are not sitting on top.
+      actionButton: {
+        zIndex: 1050,
+      },
+    },
+    overrides: {
+      MuiTypography: {
+        root: {
+          color: textPrimary,
+        },
+      },
+      MuiTableSortLabel: {
+        icon: {
+          fontSize: '1rem',
+        },
+      },
+      MuiFormLabel: {
+        filled: {
+          ...Roboto500,
+          color: isDarkTheme
+            ? THEME.PRIMARY_TEXT_DARK
+            : THEME.PRIMARY_TEXT_LIGHT,
+        },
+      },
+      MuiListSubheader: {
+        root: {
+          ...Roboto500,
+          color: isDarkTheme
+            ? THEME.PRIMARY_TEXT_DARK
+            : THEME.PRIMARY_TEXT_LIGHT,
+        },
+      },
+      MuiButton: {
+        sizeSmall: {
+          minWidth: 36,
+        },
+      },
+      MuiFab: {
+        sizeSmall: {
+          minWidth: 36,
+        },
+        extended: {
+          height: 36,
+        },
+      },
+      MuiCircularProgress: {
+        colorPrimary: {
+          color: isDarkTheme ? THEME.PRIMARY_LIGHT : THEME.PRIMARY_DARK,
+        },
+      },
+      MuiMobileStepper: {
+        dotActive: {
+          backgroundColor: isDarkTheme ? 'white' : '#000',
+        },
+      },
+      MuiTableCell: {
+        root: {
+          borderBottom: `1px solid ${
+            isDarkTheme ? THEME.TEN_PERCENT_WHITE : THEME.TEN_PERCENT_BLACK
+          }`,
+          whiteSpace: 'nowrap',
+        },
+      },
+      MuiPickersToolbar: {
+        toolbar: {
+          backgroundColor: THEME.SECONDARY,
+        },
+      },
+      MuiPickersToolbarText: {
+        toolbarTxt: {
+          color: 'rgba(255, 255, 255, 0.54)',
+        },
+        toolbarBtnSelected: {
+          color: THEME.PRIMARY_TEXT_DARK,
+        },
+      },
+      MuiPickersToolbarButton: {
+        toolbarBtn: {
+          '&:hover, &:focus': {
+            textDecoration: 'none',
+            backgroundColor: fade(textPrimary, 0.08),
+            // Reset on touch devices, it doesn't add specificity
+            '@media (hover: none)': {
+              backgroundColor: 'transparent',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+            // Rely on background color instead
+            outline: 'none',
+          },
+        },
+      },
+      MuiPickersYear: {
+        root: {
+          '&:focus': {
+            color: isDarkTheme
+              ? THEME.PRIMARY_TEXT_DARK
+              : THEME.PRIMARY_TEXT_LIGHT,
+          },
+          '&$yearSelected': {
+            color: isDarkTheme
+              ? THEME.PRIMARY_TEXT_DARK
+              : THEME.PRIMARY_TEXT_LIGHT,
+          },
+        },
+      },
+      MuiPickersClock: {
+        pin: {
+          backgroundColor: THEME.SECONDARY,
+        },
+      },
+      MuiPickersClockPointer: {
+        pointer: {
+          backgroundColor: THEME.SECONDARY,
+        },
+        thumb: {
+          borderColor: THEME.SECONDARY,
+          backgroundColor: THEME.PRIMARY_TEXT_DARK,
+        },
+        noPoint: {
+          backgroundColor: THEME.SECONDARY,
+        },
+      },
+      MuiPickersClockNumber: {
+        clockNumberSelected: {
+          color: '#fff',
+        },
+      },
+      MuiPickerDTTabs: {
+        tabs: {
+          color: '#fff',
+          backgroundColor: THEME.SECONDARY,
+          '& .MuiTabs-indicator': {
+            backgroundColor: isDarkTheme ? '#fff' : '#000',
+          },
+        },
+      },
+      MuiListItem: {
+        root: {
+          userSelect: 'text',
+        },
+      },
+      MuiChip: {
+        label: {
+          userSelect: 'text',
+        },
+        root: {
+          userSelect: 'text',
+        },
+      },
+      MuiPickersCalendarHeader: {
+        iconButton: {
+          backgroundColor: 'transparent',
+          '& span': {
+            backgroundColor: 'transparent',
+          },
+        },
+      },
+      MuiPickersDay: {
+        daySelected: {
+          backgroundColor: THEME.SECONDARY,
+          color: THEME.PRIMARY_TEXT_DARK,
+          '&:hover': {
+            backgroundColor: THEME.SECONDARY,
+          },
+        },
+        current: {
+          color: isDarkTheme
+            ? THEME.PRIMARY_TEXT_DARK
+            : THEME.PRIMARY_TEXT_LIGHT,
+        },
+      },
+      MuiPickersModal: {
+        dialogAction: {
+          color: isDarkTheme
+            ? THEME.PRIMARY_TEXT_DARK
+            : THEME.PRIMARY_TEXT_LIGHT,
+          '&:hover': {
+            backgroundColor: isDarkTheme
+              ? THEME.TEN_PERCENT_WHITE
+              : THEME.TEN_PERCENT_BLACK,
+          },
+        },
+        withAdditionalAction: {
+          '& button': {
+            color: isDarkTheme
+              ? THEME.PRIMARY_TEXT_DARK
+              : THEME.PRIMARY_TEXT_LIGHT,
+            '&:hover': {
+              backgroundColor: isDarkTheme
+                ? THEME.TEN_PERCENT_WHITE
+                : THEME.TEN_PERCENT_BLACK,
+            },
+          },
+        },
+      },
+      MuiDrawer: {
+        paper: {
+          maxWidth: 500,
+        },
+      },
+      MuiExpansionPanelSummary: {
+        root: {
+          '&$focused': {
+            backgroundColor: THEME.TEN_PERCENT_WHITE,
+          },
+        },
+      },
+      MuiMenuItem: {
+        root: {
+          color: isDarkTheme
+            ? THEME.PRIMARY_TEXT_DARK
+            : THEME.PRIMARY_TEXT_LIGHT,
+        },
+      },
+    },
+  };
+};
+
+export const theme = createMuiTheme(createTheme(true));
+
+export const TASKCLUSTER_THEME = {
+  lightTheme: createMuiTheme(createTheme(false)),
+  darkTheme: theme,
+  styleguide: {
+    StyleGuide: {
+      root: {
+        overflowY: 'scroll',
+        minHeight: '100vh',
+        backgroundColor: THEME.DARK_THEME_BACKGROUND,
+        color: theme.palette.text.primary,
+      },
+    },
+    fontFamily: {
+      base: theme.typography.fontFamily,
+    },
+    fontSize: {
+      base: theme.typography.fontSize - 1,
+      text: theme.typography.fontSize,
+      small: theme.typography.fontSize - 2,
+    },
+    color: {
+      base: theme.palette.text.primary,
+      link: theme.palette.text.primary,
+      linkHover: theme.palette.text.primary,
+      border: THEME.DIVIDER,
+      baseBackground: THEME.DARK_THEME_BACKGROUND,
+      sidebarBackground: theme.palette.primary.main,
+      codeBackground: theme.palette.primary.main,
+    },
+    sidebarWidth: THEME.DRAWER_WIDTH,
+    maxWidth: '100vw',
+  },
+};


### PR DESCRIPTION
Closes #88 
- Apply Taskcluster theme color to custom theme example in Storybook
- Fix color implementation where needed

**Screenshot Results**
| Dark Theme | Light Theme |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/29671309/75133508-701ff780-571e-11ea-83b8-79c4da51beb6.png) | ![image](https://user-images.githubusercontent.com/29671309/75133585-b412fc80-571e-11ea-94d0-fe26d020aa33.png) |

