### PR TITLE
Remove markdown-it-highlightjs package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "markdown-it": "^10.0.0",
-    "markdown-it-highlightjs": "^3.0.0",
     "mdi-react": "^6.7.0",
     "prop-types": "^15.7.2",
     "ramda": "^0.26.1"

--- a/src/components/Markdown/index.jsx
+++ b/src/components/Markdown/index.jsx
@@ -3,7 +3,6 @@ import { string, bool } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import parser from 'markdown-it';
-import highlighter from 'markdown-it-highlightjs';
 
 const useStyles = makeStyles(theme => ({
   markdown: {
@@ -31,8 +30,6 @@ function Markdown({ children, inverse }) {
    *
    */
   const markdown = parser({ linkify: true });
-
-  markdown.use(highlighter);
 
   return (
     <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -6073,11 +6073,6 @@ he@1.2.x, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^9.9.0:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
-
 highlight.js@~9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
@@ -7669,11 +7664,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.flow@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
-  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -7794,14 +7784,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-markdown-it-highlightjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-highlightjs/-/markdown-it-highlightjs-3.0.0.tgz#ed3dd619ca2b98e6bf2112d163bf444043340210"
-  integrity sha1-7T3WGcormOa/IRLRY79EQEM0AhA=
-  dependencies:
-    highlight.js "^9.9.0"
-    lodash.flow "^3.1.0"
 
 markdown-it@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
Remove `markdown-it-highlightjs` package dependency since we don't use this (and because it makes the entire component heavy)