### PR TITLE
UI enhancements

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.text.primary,
   },
   button: {
-    margin: 0,
+    margin: theme.spacing(1),
   },
 }));
 
@@ -39,6 +39,7 @@ function Header({ schema, sourceMode, toggleMode }) {
           className={classes.button}
           color="inherit"
           size="small"
+          variant="outlined" 
           onClick={toggleMode}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -37,9 +37,8 @@ function Header({ schema, sourceMode, toggleMode }) {
 
         <Button
           className={classes.button}
-          color="inherit"
+          color="secondary"
           size="small"
-          variant="outlined" 
           onClick={toggleMode}>
           {sourceMode ? 'hide' : 'show'} source
         </Button>

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -78,7 +78,9 @@ function NormalLeftRow({
     if (!type) {
       return (
         <Tooltip title={TOOLTIP_DESCRIPTIONS.noType}>
-          <WarningIcon color="inherit" />
+          <div className={classes.missingType}>
+            <WarningIcon color="inherit" />
+          </div>
         </Tooltip>
       );
     }

--- a/src/components/NormalLeftRow/index.jsx
+++ b/src/components/NormalLeftRow/index.jsx
@@ -45,16 +45,23 @@ function NormalLeftRow({
    */
   const indentSize = path.length;
   const styles = useStyles(indentSize);
+  const schemaType = schema._type;
   /**
-   * Define the name and type of the schema or sub-schema.
+   * Define the name of the schema.
    */
   const name = schema._name;
-  const schemaType = schema._type;
+  const nameText = (function createNameText(name, type) {
+    if (COMBINATION_TYPES.includes(type)) {
+      return <span className={classes.name}>{`${name}:`}</span>
+    }
+    return <span className={classes.name}>{name}</span>;
+  })(name, schemaType);
+  
 
   /**
    * Create a type symbol corresponding to the specified type.
    */
-  function createTypeSymbol(type) {
+  const typeSymbol = (function createTypeSymbol(type) {
     const bracketTypes = [
       ...NESTED_TYPES,
       LITERAL_TYPES.array,
@@ -119,7 +126,7 @@ function NormalLeftRow({
      * Default types use highlighted code format.
      */
     return <code className={classes.code}>{type}</code>;
-  }
+  })(schemaType);
 
   /**
    * Define the required/contains mark used for the schema.
@@ -232,13 +239,13 @@ function NormalLeftRow({
   })(schema);
 
   return (
-    <div key={schema.type} className={classes.row} onClick={onRefClick}>
+    <div key={schemaType} className={classes.row} onClick={onRefClick}>
       <Typography
         component="div"
         variant="subtitle2"
         className={classNames(classes.line, styles.indentation)}>
-        {name && `${name}: `}
-        {createTypeSymbol(schemaType)}
+        {name && nameText}
+        {typeSymbol}
         {requiredMark}
         {refButton}
       </Typography>

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -58,8 +58,14 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'flex-start',
   },
   /**
+   * Name text displayed within a left row.
+   */
+  name: {
+    marginRight: theme.spacing(0.5),
+  },
+  /**
    * Highlight the type for the schema or sub-schema displayed
-   * in the left panel of the schema table component.
+   * within a left row.
    */
   code: {
     backgroundColor: theme.palette.text.primary,

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -75,6 +75,10 @@ const useStyles = makeStyles(theme => ({
     fontWeight: theme.typography.subtitle2.fontWeight,
     fontFamily: theme.typography.subtitle2.fontFamily,
   },
+  missingType: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   /** Comments within the left panel (used for combination types) */
   comment: {
     color: theme.palette.text.hint,

--- a/src/components/SchemaTable/index.jsx
+++ b/src/components/SchemaTable/index.jsx
@@ -65,6 +65,9 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.text.primary,
     color: theme.palette.getContrastText(theme.palette.text.primary),
     padding: `0 ${theme.spacing(0.5)}px`,
+    fontSize: theme.typography.subtitle2.fontSize,
+    fontWeight: theme.typography.subtitle2.fontWeight,
+    fontFamily: theme.typography.subtitle2.fontFamily,
   },
   /** Comments within the left panel (used for combination types) */
   comment: {

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -7,7 +7,7 @@ import MuiTooltip from '@material-ui/core/Tooltip';
  */
 function Tooltip({ title, children }) {
   return (
-    <MuiTooltip title={title} arrow disableFocusListener enterTouchDelay={1}>
+    <MuiTooltip title={title} arrow placement="bottom-start" disableFocusListener enterTouchDelay={1}>
       <div>{children}</div>
     </MuiTooltip>
   );


### PR DESCRIPTION
- [x] vertically center the warning icon (missing type symbol)
- [x] remove colon next to type and add spacing
   - [x] keep colon for when the type is a combination type
- [x] fix ‘show source’ button to outline variant
- [x] fix tooltip hover position to left of row (at the column border)
- [x] fix font style for code blocks to match other text
