### PR TITLE
document library import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ import SchemaViewer from 'material-ui-json-schema-viewer';
 <SchemaViewer schema={jsonSchema} references={schemaReferences} />
 ```
 
+(Named import, `import { SchemaViewer } from ..`, is also supported)
+
 | Prop | Type | Required | Description |
 |:---|:---|:---|:---|
 | `schema` | Object | ✓ | A JSON schema object. |

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 import SchemaViewer from './SchemaViewer';
 
-export default { SchemaViewer };
+export { SchemaViewer };
+export default SchemaViewer;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,0 @@
-import SchemaViewer from './components/SchemaViewer';
-
-export default SchemaViewer;


### PR DESCRIPTION
This documents the import path used by Taskcluster, which seems to work.

If instead one uses

```
import SchemaViewer from 'material-ui-json-schema-viewer';
...
  <SchemaViewer schema={..} references={..} />
```

then React complains,
> Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

The other working option is
```
import SchemaViewer from 'material-ui-json-schema-viewer';
...
  <SchemaViewer.SchemaViewer schema={..} references={..} />
```

But this does not work:
```
import { SchemaViewer } from 'material-ui-json-schema-viewer';
...
  <SchemaViewer schema={..} references={..} /> /* DOES NOT WORK */
```
