### PR TITLE
Change font family to monospace on the left panel

### DIFF
--- a/src/components/SchemaTable/LeftCell.jsx
+++ b/src/components/SchemaTable/LeftCell.jsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles(theme => ({
    */
   name: {
     marginRight: theme.spacing(0.5),
+    fontFamily: 'monospace',
   },
   /**
    * Highlight the type for the schema or sub-schema displayed
@@ -55,7 +56,7 @@ const useStyles = makeStyles(theme => ({
     padding: `0 ${theme.spacing(0.5)}px`,
     fontSize: theme.typography.subtitle2.fontSize,
     fontWeight: theme.typography.subtitle2.fontWeight,
-    fontFamily: theme.typography.subtitle2.fontFamily,
+    fontFamily: 'monospace',
   },
   /**
    * Warning icon to inform missing type in LeftCell.


### PR DESCRIPTION
## Goal

Change the font family of the left panel (Schema Table component) to "monospace".

Closes #115 .

@djmitche, @helfi92, please, check if the font size looks fine to you.

## Todos:
- [x] Change the font family property of the **_names_** of the schemas to monospace;
- [x] Change the font family property of the **_types_** of the schemas to monospace.
 
## Implementation Decisions
I modified the "fontFamily" property on the "name" and "code" class names (in the "makeStyles()" Material-UI function, which starts on line 22 from LeftCell.jsx).