### PR TITLE
Fix CI by installing yarn

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,10 +8,10 @@ tasks:
       created: {$fromNow: ''}
       deadline: {$fromNow: '2 hours'}
       provisionerId: proj-taskcluster
-      workerType: ci 
+      workerType: ci
       payload:
-        maxRunTime: 3600 
-        image: node 
+        maxRunTime: 3600
+        image: node
         env:
           NO_TEST_SKIP: "true"
         command:
@@ -19,6 +19,7 @@ tasks:
           - '--login'
           - '-cx'
           - >-
+            npm install -g yarn &&
             git clone ${event.pull_request.head.repo.html_url} repo &&
             cd repo &&
             git config advice.detachedHead false &&


### PR DESCRIPTION
I can't even with this ecosystem. Use the garbage package manager to install the slightly less garbage one.

Looks like yarn got removed from the image, corepack isn't there either so we're left with just npm. The alternatives are installing yarn at runtime or switching CI to taskgraph with a custom image. I chose the easy way out given the traffic on this repo is pretty much nil.